### PR TITLE
feat(mono): relative path + cli change for ports and datadirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4932d790c723181807738cf1ac68198ab581cd699545b155601332541ee47bd"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "arbitrary",
  "num_enum",
@@ -136,7 +136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
@@ -146,12 +146,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6228abfc751a29cde117b0879b805a3e0b3b641358f063272c83ca459a56886"
+checksum = "5647fce5a168f9630f935bf7821c4207b1755184edaeba783cb4e11d35058484"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
@@ -168,7 +168,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "arbitrary",
  "rand 0.8.5",
@@ -181,7 +181,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "arbitrary",
  "k256 0.13.4",
@@ -197,7 +197,7 @@ checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
@@ -216,18 +216,18 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7a18afb0b318616b6b2b0e2e7ac5529d32a966c673b48091c9919e284e6aca"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46eb5871592c216d39192499c95a99f7175cb94104f88c307e6dc960676d9f1"
+checksum = "4b5671117c38b1c2306891f97ad3828d85487087f54ebe2c7591a055ea5bcea7"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -239,7 +239,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3c717b5298fad078cd3a418335b266eba91b511383ca9bd497f742d5975d5ab"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-sol-types",
  "serde",
  "serde_json",
@@ -257,7 +257,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
@@ -275,7 +275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-serde",
  "serde",
 ]
@@ -287,7 +287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5988a227293f949525f0a1b3e1ef728d2ef24afa96bad2b7788c6c9617fa3eec"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "k256 0.13.4",
  "rand 0.8.5",
  "serde_json",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f35429a652765189c1c5092870d8360ee7b7769b09b06d89ebaefd34676446"
+checksum = "c71738eb20c42c5fb149571e76536a0f309d142f3957c28791662b96baf77a3d"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -363,7 +363,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
@@ -395,7 +395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d05f63677e210d758cd5d6d1ce10f20c980c3560ccfbe79ba1997791862a04f"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-transport",
  "bimap",
  "futures",
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -420,13 +420,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
+checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d82952dca71173813d4e5733e2c986d8b04aea9e0f3b0a576664c232ad050a5"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -473,7 +473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fefd12e99dd6b7de387ed13ad047ce2c90d8950ca62fc48b8a457ebb8f936c61"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "serde",
  "serde_json",
 ]
@@ -484,7 +484,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25cb45ad7c0930dd62eecf164d2afe4c3d2dd2c82af85680ad1f118e1e5cb83"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-serde",
  "serde",
 ]
@@ -496,7 +496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7081d2206dca51ce23a06338d78d9b536931cc3f15134fc1c6535eb2b77f18"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-engine",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -513,7 +513,7 @@ checksum = "1464c4dd646e1bdfde86ae65ce5ba168dbb29180b478011fe87117ae46b1629b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
@@ -534,7 +534,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
@@ -554,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922d92389e5022650c4c60ffd2f9b2467c3f853764f0f74ff16a23106f9017d5"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-serde",
  "serde",
  "serde_json",
@@ -566,7 +566,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98db35cd42c90b484377e6bc44d95377a7a38a5ebee996e67754ac0446d542ab"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -580,7 +580,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bac37082c3b21283b3faf5cc0e08974272aee2f756ce1adeb26db56a5fce0d5"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -592,7 +592,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "arbitrary",
  "serde",
  "serde_json",
@@ -604,7 +604,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307324cca94354cd654d6713629f0383ec037e1ff9e3e3d547212471209860c0"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "async-trait",
  "auto_impl",
  "elliptic-curve 0.13.8",
@@ -620,7 +620,7 @@ checksum = "9fabe917ab1778e760b4701628d1cae8e028ee9d52ac6307de4e1e9286ab6b5f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
@@ -630,23 +630,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2395336745358cc47207442127c47c63801a7065ecc0aa928da844f8bb5576"
+checksum = "b0900b83f4ee1f45c640ceee596afbc118051921b9438fdb5a3175c1a7e05f8b"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed5047c9a241df94327879c2b0729155b58b941eae7805a7ada2e19436e6b39"
+checksum = "a41b1e78dde06b5e12e6702fa8c1d30621bf07728ba75b801fb801c9c6a0ba10"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -656,16 +656,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dee02a81f529c415082235129f0df8b8e60aa1601b9c9298ffe54d75f57210b"
+checksum = "91dc311a561a306664393407b88d3e53ae58581624128afd8a15faa5de3627dc"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -674,15 +674,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.81",
+ "syn 2.0.85",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f631f0bd9a9d79619b27c91b6b1ab2c4ef4e606a65192369a1ee05d40dcf81cc"
+checksum = "45d1fbee9e698f3ba176b6e7a145f4aefe6d2b746b611e8bb246fe11a0e9f6c4"
 dependencies = [
  "serde",
  "winnow",
@@ -690,12 +690,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2841af22d99e2c0f82a78fe107b6481be3dd20b89bfb067290092794734343a"
+checksum = "086f41bc6ebcd8cb15f38ba20e47be38dd03692149681ce8061c35d960dbf850"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -778,7 +778,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a46c9c4fdccda7982e7928904bd85fe235a0404ee3d7e197fff13d61eac8b4f"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "arbitrary",
  "derive_arbitrary",
@@ -864,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "aquamarine"
@@ -879,7 +879,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103db485efc3e41214fe4fda9f3dbeae2eb9082f48fd236e6095627a9422066e"
+checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
 dependencies = [
  "brotli 7.0.0",
  "flate2",
@@ -1169,7 +1169,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1180,7 +1180,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1227,7 +1227,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1395,7 +1395,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1631,7 +1631,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1642,9 +1642,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -1864,7 +1864,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2293,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2324,7 +2324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2374,7 +2374,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2398,7 +2398,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2409,7 +2409,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2531,7 +2531,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2544,7 +2544,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2565,7 +2565,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
  "unicode-xid",
 ]
 
@@ -2838,9 +2838,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -2917,7 +2917,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2929,7 +2929,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2940,7 +2940,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2960,7 +2960,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3017,7 +3017,7 @@ name = "eth-sparse-mpt"
 version = "0.1.0"
 source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=664759b#664759b53d92e64d9a2e902100691b7ff4945ece"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-trie",
  "hash-db",
@@ -3117,7 +3117,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e999563461faea0ab9bc0024e5e66adcee35881f3d5062f52f31a4070fe1522"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "itertools 0.13.0",
  "smallvec",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.81",
+ "syn 2.0.85",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -3218,7 +3218,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3244,7 +3244,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.81",
+ "syn 2.0.85",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3695,7 +3695,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3901,15 +3901,14 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7ecdc5898f6a43e08a7e2c9e2266beb98fd4dfbf2634182540fbb715245093"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
  "cfg-if",
  "dashmap 5.5.3",
- "futures-sink",
+ "futures",
  "futures-timer",
- "futures-util",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot 0.12.3",
@@ -5052,7 +5051,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5431,7 +5430,7 @@ dependencies = [
  "ed25519-dalek",
  "hkdf",
  "libsecp256k1",
- "multihash 0.19.1",
+ "multihash 0.19.2",
  "quick-protobuf",
  "sha2 0.10.8",
  "thiserror",
@@ -5724,6 +5723,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae428771d17306715c5091d446327d1cfdedc82185c65ba8423ab404e45bf10"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "metrics-exporter-prometheus"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5731,7 +5740,7 @@ checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.6.0",
- "metrics",
+ "metrics 0.23.0",
  "metrics-util",
  "quanta",
  "thiserror",
@@ -5739,14 +5748,14 @@ dependencies = [
 
 [[package]]
 name = "metrics-process"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69e6ced169644e186e060ddc15f3923fdf06862c811a867bb1e5e7c7824f4d0"
+checksum = "57ca8ecd85575fbb143b2678cb123bb818779391ec0f745b1c4a9dbabadde407"
 dependencies = [
  "libc",
  "libproc",
  "mach2",
- "metrics",
+ "metrics 0.24.0",
  "once_cell",
  "procfs 0.17.0",
  "rlimit",
@@ -5764,7 +5773,7 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "indexmap 2.6.0",
- "metrics",
+ "metrics 0.23.0",
  "num_cpus",
  "ordered-float",
  "quanta",
@@ -5778,7 +5787,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5879,7 +5888,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5956,7 +5965,7 @@ dependencies = [
  "data-encoding",
  "libp2p-identity",
  "multibase",
- "multihash 0.19.1",
+ "multihash 0.19.2",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -5990,12 +5999,12 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
 dependencies = [
  "core2",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -6250,7 +6259,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6311,7 +6320,7 @@ checksum = "21aad1fbf80d2bcd7406880efc7ba109365f44bbb72896758ddcbfa46bf1592c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
@@ -6327,7 +6336,7 @@ checksum = "6e1b8a9b70da0e027242ec1762f0f3a386278b6291d00d12ff5a64929dc19f68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-sol-types",
  "serde",
  "serde_repr",
@@ -6341,7 +6350,7 @@ checksum = "783ce4ebc0a994eee2188431511b16692b704e1e8fff0c77d8c0354d3c2b1fc8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-eth",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
@@ -6355,7 +6364,7 @@ checksum = "bf300a82ae2d30e2255bfea87a2259da49f63a25a44db561ae64cc9e3084139f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-serde",
  "hashbrown 0.14.5",
@@ -6372,7 +6381,7 @@ checksum = "e281fbfc2198b7c0c16457d6524f83d192662bc9f3df70f24c3038d4521616df"
 dependencies = [
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "cfg-if",
@@ -6389,7 +6398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2947272a81ebf988f4804b6f0f6a7c0b2f6f89a908cb410e36f8f3828f81c778"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-engine",
  "alloy-serde",
  "derive_more 1.0.0",
@@ -6453,7 +6462,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6716,16 +6725,16 @@ dependencies = [
 
 [[package]]
 name = "ph"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2662713b3e8e02977b289a7ada32d672ae5477b5c23f290e5999122d53658847"
+checksum = "b2fbaf8da280599aae4047ea0659a1e79cf61739bce5bdc50ca88dc7e6357060"
 dependencies = [
  "aligned-vec",
  "binout",
  "bitm",
  "dyn_size_of",
  "rayon",
- "wyhash",
+ "seedable_hash",
 ]
 
 [[package]]
@@ -6797,7 +6806,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6820,29 +6829,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -7249,12 +7258,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7344,14 +7353,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -7457,7 +7466,7 @@ checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7721,7 +7730,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-node-bindings",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rlp",
@@ -7876,9 +7885,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8136,7 +8145,7 @@ dependencies = [
  "alloy-rlp",
  "futures-core",
  "futures-util",
- "metrics",
+ "metrics 0.23.0",
  "reth-chainspec",
  "reth-metrics",
  "reth-payload-builder",
@@ -8157,7 +8166,7 @@ version = "1.0.6"
 dependencies = [
  "futures",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "reth-blockchain-tree-api",
  "reth-chainspec",
  "reth-db-api",
@@ -8190,7 +8199,7 @@ version = "1.0.6"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
- "metrics",
+ "metrics 0.23.0",
  "parking_lot 0.12.3",
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -8233,7 +8242,7 @@ dependencies = [
  "alloy-signer-local",
  "auto_impl",
  "derive_more 1.0.0",
- "metrics",
+ "metrics 0.23.0",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
@@ -8257,7 +8266,7 @@ dependencies = [
  "alloy-chains",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-trie",
  "auto_impl",
  "derive_more 1.0.0",
@@ -8336,7 +8345,7 @@ name = "reth-cli-util"
 version = "1.0.6"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "eyre",
  "libc",
  "rand 0.8.5",
@@ -8352,7 +8361,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
@@ -8367,7 +8376,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8430,7 +8439,7 @@ dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "eyre",
- "metrics",
+ "metrics 0.23.0",
  "page_size",
  "paste",
  "reth-db-api",
@@ -8460,7 +8469,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "derive_more 1.0.0",
- "metrics",
+ "metrics 0.23.0",
  "modular-bitfield",
  "parity-scale-codec",
  "proptest",
@@ -8517,7 +8526,7 @@ dependencies = [
 name = "reth-discv4"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "discv5",
  "enr 0.12.1",
@@ -8540,14 +8549,14 @@ dependencies = [
 name = "reth-discv5"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "derive_more 1.0.0",
  "discv5",
  "enr 0.12.1",
  "futures",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "rand 0.8.5",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -8563,7 +8572,7 @@ dependencies = [
 name = "reth-dns-discovery"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "data-encoding",
  "enr 0.12.1",
  "linked_hash_set",
@@ -8588,7 +8597,7 @@ dependencies = [
  "futures",
  "futures-util",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "pin-project",
  "rayon",
  "reth-config",
@@ -8611,7 +8620,7 @@ name = "reth-ecies"
 version = "1.0.6"
 dependencies = [
  "aes",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -8673,7 +8682,7 @@ name = "reth-engine-tree"
 version = "1.0.6"
 dependencies = [
  "futures",
- "metrics",
+ "metrics 0.23.0",
  "reth-beacon-consensus",
  "reth-blockchain-tree",
  "reth-blockchain-tree-api",
@@ -8815,7 +8824,7 @@ name = "reth-ethereum-forks"
 version = "1.0.6"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "arbitrary",
  "auto_impl",
@@ -8916,7 +8925,7 @@ name = "reth-execution-errors"
 version = "1.0.6"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "derive_more 1.0.0",
  "nybbles",
@@ -8942,7 +8951,7 @@ version = "1.0.6"
 dependencies = [
  "eyre",
  "futures",
- "metrics",
+ "metrics 0.23.0",
  "reth-config",
  "reth-evm",
  "reth-exex-types",
@@ -8966,7 +8975,7 @@ dependencies = [
 name = "reth-exex-types"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "reth-provider",
 ]
 
@@ -9027,7 +9036,7 @@ name = "reth-metrics"
 version = "1.0.6"
 dependencies = [
  "futures",
- "metrics",
+ "metrics 0.23.0",
  "reth-metrics-derive",
  "tokio",
  "tokio-util",
@@ -9040,14 +9049,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "reth-net-banlist"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
 ]
 
 [[package]]
@@ -9073,7 +9082,7 @@ dependencies = [
  "enr 0.12.1",
  "futures",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
@@ -9112,7 +9121,7 @@ dependencies = [
 name = "reth-network-api"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-admin",
  "auto_impl",
  "derive_more 1.0.0",
@@ -9151,7 +9160,7 @@ dependencies = [
 name = "reth-network-peers"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "enr 0.12.1",
  "secp256k1 0.29.1",
@@ -9367,7 +9376,7 @@ dependencies = [
  "eyre",
  "http 1.1.0",
  "jsonrpsee 0.24.7",
- "metrics",
+ "metrics 0.23.0",
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
@@ -9402,7 +9411,7 @@ version = "1.0.6"
 name = "reth-optimism-rpc"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "jsonrpsee-types 0.24.7",
  "op-alloy-network",
  "parking_lot 0.12.3",
@@ -9434,7 +9443,7 @@ name = "reth-payload-builder"
 version = "1.0.6"
 dependencies = [
  "futures-util",
- "metrics",
+ "metrics 0.23.0",
  "pin-project",
  "reth-errors",
  "reth-ethereum-engine-primitives",
@@ -9483,7 +9492,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-serde",
@@ -9518,7 +9527,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "arbitrary",
@@ -9542,7 +9551,7 @@ dependencies = [
  "auto_impl",
  "dashmap 6.1.0",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "once_cell",
  "parking_lot 0.12.3",
  "rayon",
@@ -9576,9 +9585,9 @@ dependencies = [
 name = "reth-prune"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "rayon",
  "reth-chainspec",
  "reth-config",
@@ -9601,7 +9610,7 @@ dependencies = [
 name = "reth-prune-types"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "bytes",
  "derive_more 1.0.0",
  "modular-bitfield",
@@ -9631,7 +9640,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "async-trait",
  "derive_more 1.0.0",
@@ -9698,7 +9707,7 @@ version = "1.0.6"
 dependencies = [
  "http 1.1.0",
  "jsonrpsee 0.24.7",
- "metrics",
+ "metrics 0.23.0",
  "pin-project",
  "reth-chainspec",
  "reth-engine-primitives",
@@ -9731,7 +9740,7 @@ dependencies = [
  "async-trait",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
- "metrics",
+ "metrics 0.23.0",
  "reth-beacon-consensus",
  "reth-chainspec",
  "reth-engine-primitives",
@@ -9796,7 +9805,7 @@ dependencies = [
  "futures",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
- "metrics",
+ "metrics 0.23.0",
  "rand 0.8.5",
  "reth-chain-state",
  "reth-chainspec",
@@ -9840,7 +9849,7 @@ dependencies = [
 name = "reth-rpc-server-types"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
  "reth-errors",
@@ -9855,7 +9864,7 @@ dependencies = [
 name = "reth-rpc-types"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
@@ -9918,11 +9927,11 @@ dependencies = [
 name = "reth-stages-api"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "aquamarine",
  "auto_impl",
  "futures-util",
- "metrics",
+ "metrics 0.23.0",
  "reth-consensus",
  "reth-db-api",
  "reth-errors",
@@ -9944,7 +9953,7 @@ dependencies = [
 name = "reth-stages-types"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
@@ -9956,7 +9965,7 @@ dependencies = [
 name = "reth-static-file"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "parking_lot 0.12.3",
  "rayon",
  "reth-db",
@@ -9975,7 +9984,7 @@ dependencies = [
 name = "reth-static-file-types"
 version = "1.0.6"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "clap",
  "derive_more 1.0.0",
  "serde",
@@ -10014,7 +10023,7 @@ dependencies = [
  "auto_impl",
  "dyn-clone",
  "futures-util",
- "metrics",
+ "metrics 0.23.0",
  "pin-project",
  "rayon",
  "reth-metrics",
@@ -10056,7 +10065,7 @@ dependencies = [
  "auto_impl",
  "bitflags 2.6.0",
  "futures-util",
- "metrics",
+ "metrics 0.23.0",
  "parking_lot 0.12.3",
  "reth-chain-state",
  "reth-chainspec",
@@ -10086,7 +10095,7 @@ dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "rayon",
  "reth-execution-errors",
  "reth-metrics",
@@ -10105,7 +10114,7 @@ version = "1.0.6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rlp",
  "alloy-trie",
  "arbitrary",
@@ -10129,7 +10138,7 @@ dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "rayon",
  "reth-db",
  "reth-db-api",
@@ -10151,7 +10160,7 @@ dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
  "itertools 0.13.0",
- "metrics",
+ "metrics 0.23.0",
  "rayon",
  "reth-db",
  "reth-db-api",
@@ -10184,7 +10193,7 @@ dependencies = [
 name = "revm-inspectors"
 version = "0.6.0"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
@@ -10225,7 +10234,7 @@ name = "revm-primitives"
 version = "9.0.1"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "auto_impl",
  "bitflags 2.6.0",
  "bitvec",
@@ -10660,26 +10669,26 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+checksum = "1aa7ffc1c0ef49b0452c6e2986abf2b07743320641ffd5fc63d552458e3b779b"
 dependencies = [
  "cfg-if",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
 ]
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+checksum = "46385cc24172cf615450267463f937c10072516359b3ff1cb24228a4a08bf951"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -10844,6 +10853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "seedable_hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed064ed6aaf88eb6a28ae191f5871a7fcdd2858e1cd6e1ffcc746baef8cd3cfd"
+dependencies = [
+ "wyhash",
+]
+
+[[package]]
 name = "selectors"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10909,9 +10927,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -10927,13 +10945,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -10968,7 +10986,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -11019,7 +11037,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -11634,7 +11652,7 @@ name = "ssz_rs"
 version = "0.9.0"
 source = "git+https://github.com/ralexstokes/ssz-rs.git#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
 dependencies = [
- "alloy-primitives 0.8.8",
+ "alloy-primitives 0.8.9",
  "bitvec",
  "serde",
  "sha2 0.9.9",
@@ -11668,7 +11686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -11766,7 +11784,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -11779,7 +11797,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -11844,9 +11862,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.81"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11855,14 +11873,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfc1bfd06acc78f16d8fd3ef846bc222ee7002468d10a7dce8d703d6eab89a3"
+checksum = "9d5e0c2ea8db64b2898b62ea2fbd60204ca95e0b2c6bdf53ff768bbe916fbe4d"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -12001,28 +12019,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "reqwest 0.11.27",
- "syn 2.0.81",
+ "syn 2.0.85",
  "which",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -12164,9 +12182,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -12188,7 +12206,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -12445,7 +12463,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -12998,7 +13016,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -13032,7 +13050,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -13238,7 +13256,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -13249,7 +13267,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -13525,7 +13543,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -13545,7 +13563,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.81",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,18 +14,18 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aead"
@@ -85,6 +85,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,10 +116,11 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.23"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1752d7d62e2665da650a36d84abbf239f812534475d51f072a49a533513b7cdd"
+checksum = "d4932d790c723181807738cf1ac68198ab581cd699545b155601332541ee47bd"
 dependencies = [
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "arbitrary",
  "num_enum",
@@ -121,12 +131,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4177d135789e282e925092be8939d421b701c6d92c0a16679faa659d9166289d"
+checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
@@ -136,12 +146,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95d76a38cae906fd394a5afb0736aaceee5432efe76addfd71048e623e208af"
+checksum = "e6228abfc751a29cde117b0879b805a3e0b3b641358f063272c83ca459a56886"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
@@ -149,7 +159,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.6.15",
+ "winnow",
 ]
 
 [[package]]
@@ -158,7 +168,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "arbitrary",
  "rand 0.8.5",
@@ -167,14 +177,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d319bb544ca6caeab58c39cea8921c55d924d4f68f2c60f24f914673f9a74a"
+checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "arbitrary",
- "k256 0.13.3",
+ "k256 0.13.4",
  "rand 0.8.5",
  "serde",
 ]
@@ -187,7 +197,7 @@ checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
@@ -202,22 +212,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b85dfc693e4a1193f0372a8f789df12ab51fcbe7be0733baa04939a86dd813b"
+checksum = "3a7a18afb0b318616b6b2b0e2e7ac5529d32a966c673b48091c9919e284e6aca"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c66eec1acdd96b39b995b8f5ee5239bc0c871d62c527ae1ac9fd1d7fecd455"
+checksum = "d46eb5871592c216d39192499c95a99f7175cb94104f88c307e6dc960676d9f1"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -225,11 +235,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4207166c79cfdf7f3bed24bbc84f5c7c5d4db1970f8c82e3fcc76257f16d2166"
+checksum = "d3c717b5298fad078cd3a418335b266eba91b511383ca9bd497f742d5975d5ab"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-sol-types",
  "serde",
  "serde_json",
@@ -239,15 +249,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe2802d5b8c632f18d68c352073378f02a3407c1b6a4487194e7d21ab0f002"
+checksum = "fb3705ce7d8602132bcf5ac7a1dd293a42adc2f183abf5907c30ac535ceca049"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
@@ -260,24 +270,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396c07726030fa0f9dab5da8c71ccd69d5eb74a7fe1072b7ae453a67e4fe553e"
+checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-eips",
+ "alloy-primitives 0.8.8",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c847311cc7386684ef38ab404069d795bee07da945f63d884265436870a17276"
+checksum = "5988a227293f949525f0a1b3e1ef728d2ef24afa96bad2b7788c6c9617fa3eec"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 0.8.7",
- "k256 0.13.3",
+ "alloy-primitives 0.8.8",
+ "k256 0.13.4",
+ "rand 0.8.5",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -298,7 +310,7 @@ dependencies = [
  "derive_more 0.99.18",
  "hex-literal",
  "itoa",
- "k256 0.13.3",
+ "k256 0.13.4",
  "keccak-asm",
  "proptest",
  "rand 0.8.5",
@@ -309,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb848c43f6b06ae3de2e4a67496cbbabd78ae87db0f1248934f15d76192c6a"
+checksum = "38f35429a652765189c1c5092870d8360ee7b7769b09b06d89ebaefd34676446"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -326,7 +338,7 @@ dependencies = [
  "hex-literal",
  "indexmap 2.6.0",
  "itoa",
- "k256 0.13.3",
+ "k256 0.13.4",
  "keccak-asm",
  "paste",
  "proptest",
@@ -341,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1376948df782ffee83a54cac4b2aba14134edd997229a3db97da0a606586eb5c"
+checksum = "927f708dd457ed63420400ee5f06945df9632d5d101851952056840426a10dc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -351,7 +363,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
@@ -362,12 +374,12 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap 6.0.1",
+ "dashmap 6.1.0",
  "futures",
  "futures-utils-wasm",
  "lru",
  "pin-project",
- "reqwest 0.12.5",
+ "reqwest 0.12.8",
  "serde",
  "serde_json",
  "thiserror",
@@ -378,12 +390,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa73f976e7b6341f3f8a404241cf04f883d40212cd4f2633c66d99de472e262c"
+checksum = "2d05f63677e210d758cd5d6d1ce10f20c980c3560ccfbe79ba1997791862a04f"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-transport",
  "bimap",
  "futures",
@@ -391,15 +403,15 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.1",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43b18702501396fa9bcdeecd533bc85fac75150d308fc0f6800a01e6234a003"
+checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -408,23 +420,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83524c1f6162fcb5b0decf775498a125066c86dda6066ed609531b0e912f85a"
+checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02378418a429f8a14a0ad8ffaa15b2d25ff34914fc4a1e366513c6a3800e03b3"
+checksum = "7d82952dca71173813d4e5733e2c986d8b04aea9e0f3b0a576664c232ad050a5"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -432,21 +444,21 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.5",
+ "reqwest 0.12.8",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ae4c4fbd37d9996f501fbc7176405aab97ae3a5772789be06ef0e7c4dad6dd"
+checksum = "64333d639f2a0cf73491813c629a405744e16343a4bc5640931be707c345ecc5"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -456,23 +468,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594b7cb723759c7b438c95a3bbd2e391760c03ee857443070758aaf2593ae84e"
+checksum = "fefd12e99dd6b7de387ed13ad047ce2c90d8950ca62fc48b8a457ebb8f936c61"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140b079c6fda14d9586432bf988b46ac0e04871ca313c9e00aa85cc808105e8a"
+checksum = "d25cb45ad7c0930dd62eecf164d2afe4c3d2dd2c82af85680ad1f118e1e5cb83"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-serde",
  "serde",
 ]
@@ -484,7 +496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7081d2206dca51ce23a06338d78d9b536931cc3f15134fc1c6535eb2b77f18"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-engine",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -501,13 +513,13 @@ checksum = "1464c4dd646e1bdfde86ae65ce5ba168dbb29180b478011fe87117ae46b1629b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-types 0.24.7",
  "jsonwebtoken 9.3.0",
  "rand 0.8.5",
  "serde",
@@ -515,32 +527,34 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bb3506ab1cf415d4752778c93e102050399fb8de97b7da405a5bf3e31f5f3b"
+checksum = "83aa984386deda02482660aa31cb8ca1e63d533f1c31a52d7d181ac5ec68e9b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
+ "cfg-if",
+ "derive_more 1.0.0",
+ "hashbrown 0.14.5",
  "itertools 0.13.0",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-types 0.24.7",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8cb848b66617f7d58b576bfc416854c4e9ae8d35e14f5077c0c779048f280"
+checksum = "922d92389e5022650c4c60ffd2f9b2467c3f853764f0f74ff16a23106f9017d5"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-serde",
  "serde",
  "serde_json",
@@ -548,11 +562,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16cca915e0aab3b2657b4f9efe02eb88e5483905fb6d244749652aae14e5f92e"
+checksum = "98db35cd42c90b484377e6bc44d95377a7a38a5ebee996e67754ac0446d542ab"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -562,11 +576,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68eede4bd722bb872222efbbfbccc8f9b86e597143934b8ce556d3e0487bb662"
+checksum = "6bac37082c3b21283b3faf5cc0e08974272aee2f756ce1adeb26db56a5fce0d5"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -574,11 +588,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae417978015f573b4a8c02af17f88558fb22e3fccd12e8a910cf6a2ff331cfcb"
+checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "arbitrary",
  "serde",
  "serde_json",
@@ -586,53 +600,53 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b750c9b61ac0646f8f4a61231c2732a337b2c829866fc9a191b96b7eedf80ffe"
+checksum = "307324cca94354cd654d6713629f0383ec037e1ff9e3e3d547212471209860c0"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "async-trait",
  "auto_impl",
  "elliptic-curve 0.13.8",
- "k256 0.13.3",
+ "k256 0.13.4",
  "thiserror",
 ]
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c640f9343e8f741f837c345c5ea30239ba77938b3691b884c736834853bd16c"
+checksum = "9fabe917ab1778e760b4701628d1cae8e028ee9d52ac6307de4e1e9286ab6b5f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-signer",
  "async-trait",
- "k256 0.13.3",
+ "k256 0.13.4",
  "rand 0.8.5",
  "thiserror",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661c516eb1fa3294cc7f2fb8955b3b609d639c282ac81a4eedb14d3046db503a"
+checksum = "3b2395336745358cc47207442127c47c63801a7065ecc0aa928da844f8bb5576"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbabb8fc3d75a0c2cea5215be22e7a267e3efde835b0f2a8922f5e3f5d47683"
+checksum = "9ed5047c9a241df94327879c2b0729155b58b941eae7805a7ada2e19436e6b39"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -642,16 +656,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16517f2af03064485150d89746b8ffdcdbc9b6eeb3d536fb66efd7c2846fbc75"
+checksum = "5dee02a81f529c415082235129f0df8b8e60aa1601b9c9298ffe54d75f57210b"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -660,28 +674,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.72",
+ "syn 2.0.81",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07ebb0c1674ff8cbb08378d7c2e0e27919d2a2dae07ad3bca26174deda8d389"
+checksum = "f631f0bd9a9d79619b27c91b6b1ab2c4ef4e606a65192369a1ee05d40dcf81cc"
 dependencies = [
  "serde",
- "winnow 0.6.15",
+ "winnow",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e448d879903624863f608c552d10efb0e0905ddbee98b0049412799911eb062"
+checksum = "c2841af22d99e2c0f82a78fe107b6481be3dd20b89bfb067290092794734343a"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -689,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2799749ca692ae145f54968778877afd7c95e788488f176cfdfcf2a8abeb2062"
+checksum = "33616b2edf7454302a1d48084db185e52c309f73f6c10be99b0fe39354b3f1e9"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -701,31 +715,31 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc10c4dd932f66e0db6cc5735241e0c17a6a18564b430bbc1839f7db18587a93"
+checksum = "a944f5310c690b62bbb3e7e5ce34527cbd36b2d18532a797af123271ce595a49"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.5",
+ "reqwest 0.12.8",
  "serde_json",
- "tower",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f39f88798c3282914079a3eda3ea8b9fbf21e383a0ce85958b4f1c170d222f"
+checksum = "09fd8491249f74d16ec979b1f5672377b12ebb818e6056478ffa386954dbd350"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -742,15 +756,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e732028930aa17b7edd464a9711365417635e984028fcc7176393ccea22c00"
+checksum = "a9704761f6297fe482276bee7f77a93cb42bd541c2bd6c1c560b6f3a9ece672e"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http 1.1.0",
- "rustls 0.23.12",
+ "rustls 0.23.15",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -760,11 +774,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398a977d774db13446b8cead8cfa9517aebf9e03fc8a1512892dc1e03e70bb04"
+checksum = "0a46c9c4fdccda7982e7928904bd85fe235a0404ee3d7e197fff13d61eac8b4f"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "arbitrary",
  "derive_arbitrary",
@@ -801,9 +815,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -816,33 +830,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -850,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "aquamarine"
@@ -865,7 +879,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -920,7 +934,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "zeroize",
 ]
 
@@ -1018,15 +1032,15 @@ checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow-format"
@@ -1064,7 +1078,7 @@ dependencies = [
  "parquet2",
  "regex",
  "regex-syntax 0.6.29",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
@@ -1099,18 +1113,18 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.12"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
+checksum = "103db485efc3e41214fe4fda9f3dbeae2eb9082f48fd236e6095627a9422066e"
 dependencies = [
- "brotli 6.0.0",
+ "brotli 7.0.0",
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite",
  "tokio",
  "zstd 0.13.2",
- "zstd-safe 7.2.0",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -1138,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -1149,24 +1163,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1177,7 +1191,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures",
  "pharos",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -1213,14 +1227,14 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backon"
@@ -1228,7 +1242,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d67782c3f868daa71d3533538e98a8e13713231969def7536e8039606fc46bf0"
 dependencies = [
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-core",
  "pin-project",
  "tokio",
@@ -1236,17 +1250,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1366,14 +1380,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1381,14 +1395,32 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.81",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "binout"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60b1af88a588fca5fe424ae7d735bc52814f80ff57614f57043cc4e2024f2ea"
+checksum = "581d67184175e0c94926cb5e82df97bb6e0d8261d27a88a6ead80994ee73a4ac"
 
 [[package]]
 name = "bit-set"
@@ -1423,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "bitm"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06e8e5bec3490b9f6f3adbb78aa4f53e8396fd9994e8a62a346b44ea7c15f35"
+checksum = "e7edec3daafc233e78a219c85a77bcf535ee267b0fae7a1aad96bd1a67add5d3"
 dependencies = [
  "dyn_size_of",
 ]
@@ -1504,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1551,20 +1583,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "serde",
 ]
 
 [[package]]
 name = "built"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4"
+checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
 dependencies = [
  "chrono",
  "git2",
@@ -1584,22 +1616,22 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1610,9 +1642,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde",
 ]
@@ -1655,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -1708,12 +1740,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1802,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.10"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1812,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.10"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1824,21 +1857,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "coins-bip32"
@@ -1850,7 +1883,7 @@ dependencies = [
  "coins-core",
  "digest 0.10.7",
  "hmac 0.12.1",
- "k256 0.13.3",
+ "k256 0.13.4",
  "serde",
  "sha2 0.10.8",
  "thiserror",
@@ -1894,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "combine"
@@ -1966,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1985,9 +2018,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
 dependencies = [
  "const_format_proc_macros",
  "konst",
@@ -1995,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2037,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -2052,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -2260,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2291,7 +2324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2328,7 +2361,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -2341,7 +2374,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2365,7 +2398,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2376,7 +2409,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2394,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2498,7 +2531,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2510,8 +2543,8 @@ dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
- "syn 2.0.72",
+ "rustc_version 0.4.1",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2532,7 +2565,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
  "unicode-xid",
 ]
 
@@ -2621,7 +2654,7 @@ dependencies = [
  "libp2p-identity",
  "lru",
  "more-asserts",
- "multiaddr 0.18.1",
+ "multiaddr 0.18.2",
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "smallvec",
@@ -2667,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -2679,9 +2712,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "dyn_size_of"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d4f78a40b1ec35bf8cafdaaf607ba2f773c366b0b3bda48937cacd7a8d5134"
+checksum = "fdbac012a81cc46ca554aceae23c52f4f55adb343f2f32ca99bb4e5ef868cee2"
 
 [[package]]
 name = "ecdsa"
@@ -2736,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "ego-tree"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591"
+checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
 name = "either"
@@ -2846,7 +2879,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "hex",
- "k256 0.13.3",
+ "k256 0.13.4",
  "log",
  "rand 0.8.5",
  "rlp 0.5.2",
@@ -2866,10 +2899,10 @@ dependencies = [
  "bytes",
  "ed25519-dalek",
  "hex",
- "k256 0.13.3",
+ "k256 0.13.4",
  "log",
  "rand 0.8.5",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "serde",
  "sha3",
  "zeroize",
@@ -2877,14 +2910,14 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2896,18 +2929,38 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "enumn"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
+]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2964,7 +3017,7 @@ name = "eth-sparse-mpt"
 version = "0.1.0"
 source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=664759b#664759b53d92e64d9a2e902100691b7ff4945ece"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-trie",
  "hash-db",
@@ -2975,8 +3028,8 @@ dependencies = [
  "reth-provider",
  "reth-trie",
  "reth-trie-db",
- "revm",
- "revm-primitives",
+ "revm 14.0.1",
+ "revm-primitives 9.0.1",
  "rustc-hash 2.0.0",
  "serde",
  "serde_json",
@@ -3064,7 +3117,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e999563461faea0ab9bc0024e5e66adcee35881f3d5062f52f31a4070fe1522"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "itertools 0.13.0",
  "smallvec",
 ]
@@ -3078,7 +3131,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3147,8 +3200,8 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.72",
- "toml 0.8.15",
+ "syn 2.0.81",
+ "toml 0.8.19",
  "walkdir",
 ]
 
@@ -3165,7 +3218,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3182,7 +3235,7 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "ethabi",
  "generic-array",
- "k256 0.13.3",
+ "k256 0.13.4",
  "num_enum",
  "once_cell",
  "open-fastrlp",
@@ -3191,7 +3244,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.72",
+ "syn 2.0.81",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3345,11 +3398,11 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "exponential-backoff"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f78d87d930eee4b5686a2ab032de499c72bd1e954b84262bb03492a0f932cd"
+checksum = "949eb68d436415e37b7a69c49a9900d5337616b0e420377ccc48038b86261e16"
 dependencies = [
- "rand 0.8.5",
+ "fastrand 2.1.1",
 ]
 
 [[package]]
@@ -3385,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fastrlp"
@@ -3456,9 +3509,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3466,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3552,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3567,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3577,15 +3630,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3605,9 +3658,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -3636,26 +3689,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -3669,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3756,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
@@ -3848,14 +3901,15 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+checksum = "7a7ecdc5898f6a43e08a7e2c9e2266beb98fd4dfbf2634182540fbb715245093"
 dependencies = [
  "cfg-if",
  "dashmap 5.5.3",
- "futures",
+ "futures-sink",
  "futures-timer",
+ "futures-util",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot 0.12.3",
@@ -3891,7 +3945,6 @@ dependencies = [
 [[package]]
 name = "gwyneth"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "alloy-serde",
@@ -3899,7 +3952,7 @@ dependencies = [
  "eyre",
  "futures",
  "futures-util",
- "jsonrpsee 0.24.3",
+ "jsonrpsee 0.24.7",
  "reth-auto-seal-consensus",
  "reth-basic-payload-builder",
  "reth-beacon-consensus",
@@ -3934,7 +3987,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 14.0.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -3964,9 +4017,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4033,6 +4086,8 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
  "serde",
 ]
@@ -4109,6 +4164,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -4282,9 +4343,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -4316,9 +4377,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4340,14 +4401,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -4367,7 +4428,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -4377,22 +4438,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.12",
- "rustls-native-certs 0.7.1",
+ "rustls 0.23.15",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -4402,7 +4463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -4416,7 +4477,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4426,29 +4487,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -4619,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "4.0.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924df4f0e24e2e7f9cdd90babb0b96f93b20f3ecfa949ea9e6613756b8c8e1bf"
+checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
 
 [[package]]
 name = "integer-sqrt"
@@ -4656,20 +4716,20 @@ dependencies = [
  "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "iri-string"
-version = "0.7.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5f6c2df22c009ac44f6f1499308e7a3ac7ba42cd2378475cc691510e1eef1b"
+checksum = "dc0f0a572e8ffe56e2ff4f769f32ffe919282c3916799f8b68688b6030063bea"
 dependencies = [
  "memchr",
  "serde",
@@ -4677,20 +4737,20 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -4706,6 +4766,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -4756,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4780,51 +4849,51 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affdc52f7596ccb2d7645231fc6163bb314630c989b64998f3699a28b4d5d4dc"
+checksum = "138572befc78a9793240645926f30161f8b4143d2be18d09e44ed9814bd7ee2c"
 dependencies = [
- "jsonrpsee-client-transport 0.20.3",
- "jsonrpsee-core 0.20.3",
- "jsonrpsee-http-client 0.20.3",
- "jsonrpsee-proc-macros 0.20.3",
- "jsonrpsee-server 0.20.3",
- "jsonrpsee-types 0.20.3",
- "jsonrpsee-wasm-client 0.20.3",
- "jsonrpsee-ws-client 0.20.3",
+ "jsonrpsee-client-transport 0.20.4",
+ "jsonrpsee-core 0.20.4",
+ "jsonrpsee-http-client 0.20.4",
+ "jsonrpsee-proc-macros 0.20.4",
+ "jsonrpsee-server 0.20.4",
+ "jsonrpsee-types 0.20.4",
+ "jsonrpsee-wasm-client 0.20.4",
+ "jsonrpsee-ws-client 0.20.4",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec465b607a36dc5dd45d48b7689bc83f679f66a3ac6b6b21cc787a11e0f8685"
+checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
 dependencies = [
- "jsonrpsee-client-transport 0.24.3",
- "jsonrpsee-core 0.24.3",
- "jsonrpsee-http-client 0.24.3",
- "jsonrpsee-proc-macros 0.24.3",
- "jsonrpsee-server 0.24.3",
- "jsonrpsee-types 0.24.3",
- "jsonrpsee-wasm-client 0.24.3",
- "jsonrpsee-ws-client 0.24.3",
+ "jsonrpsee-client-transport 0.24.7",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-http-client 0.24.7",
+ "jsonrpsee-proc-macros 0.24.7",
+ "jsonrpsee-server 0.24.7",
+ "jsonrpsee-types 0.24.7",
+ "jsonrpsee-wasm-client 0.24.7",
+ "jsonrpsee-ws-client 0.24.7",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b005c793122d03217da09af68ba9383363caa950b90d3436106df8cabce935"
+checksum = "5c671353e4adf926799107bd7f5724a06b6bc0a333db442a0843c58640bdd0c1"
 dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net 0.4.0",
  "http 0.2.12",
- "jsonrpsee-core 0.20.3",
+ "jsonrpsee-core 0.20.4",
  "pin-project",
  "rustls-native-certs 0.6.3",
  "soketto 0.7.1",
@@ -4839,18 +4908,18 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f0977f9c15694371b8024c35ab58ca043dbbf4b51ccb03db8858a021241df1"
+checksum = "548125b159ba1314104f5bb5f38519e03a41862786aa3925cf349aae9cdd546e"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net 0.6.0",
  "http 1.1.0",
- "jsonrpsee-core 0.24.3",
+ "jsonrpsee-core 0.24.7",
  "pin-project",
- "rustls 0.23.12",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.0",
@@ -4864,9 +4933,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2327ba8df2fdbd5e897e2b5ed25ce7f299d345b9736b6828814c3dbd1fd47b"
+checksum = "f24ea59b037b6b9b0e2ebe2c30a3e782b56bd7c76dcc5d6d70ba55d442af56e3"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -4874,8 +4943,8 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "hyper 0.14.30",
- "jsonrpsee-types 0.20.3",
+ "hyper 0.14.31",
+ "jsonrpsee-types 0.20.4",
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "rustc-hash 1.1.0",
@@ -4890,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e942c55635fbf5dc421938b8558a8141c7e773720640f4f1dbe1f4164ca4e221"
+checksum = "f2882f6f8acb9fdaec7cefc4fd607119a9bd709831df7d7672a1d3b644628280"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4901,7 +4970,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-types 0.24.7",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
@@ -4917,54 +4986,54 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f80c17f62c7653ce767e3d7288b793dfec920f97067ceb189ebdd3570f2bc20"
+checksum = "57c7b9f95208927653e7965a98525e7fc641781cab89f0e27c43fa2974405683"
 dependencies = [
  "async-trait",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
- "jsonrpsee-core 0.20.3",
- "jsonrpsee-types 0.20.3",
+ "jsonrpsee-core 0.20.4",
+ "jsonrpsee-types 0.20.4",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33774602df12b68a2310b38a535733c477ca4a498751739f89fe8dbbb62ec4c"
+checksum = "b3638bc4617f96675973253b3a45006933bde93c2fd8a6170b33c777cc389e5b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper 1.5.0",
+ "hyper-rustls 0.27.3",
  "hyper-util",
- "jsonrpsee-core 0.24.3",
- "jsonrpsee-types 0.24.3",
- "rustls 0.23.12",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
+ "rustls 0.23.15",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29110019693a4fa2dbda04876499d098fa16d70eba06b1e6e2b3f1b251419515"
+checksum = "dcc0eba68ba205452bcb4c7b80a79ddcb3bf36c261a841b239433142db632d24"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-crate 1.1.3",
@@ -4975,28 +5044,28 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b07a2daf52077ab1b197aea69a5c990c060143835bf04c77070e98903791715"
+checksum = "c06c01ae0007548e73412c08e2285ffe5d723195bf268bce67b1b77c3bb2a14d"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c39a00449c9ef3f50b84fc00fc4acba20ef8f559f07902244abf4c15c5ab9c"
+checksum = "a482bc4e25eebd0adb61a3468c722763c381225bd3ec46e926f709df8a8eb548"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
- "jsonrpsee-core 0.20.3",
- "jsonrpsee-types 0.20.3",
+ "hyper 0.14.31",
+ "jsonrpsee-core 0.20.4",
+ "jsonrpsee-types 0.20.4",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -5005,24 +5074,24 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038fb697a709bec7134e9ccbdbecfea0e2d15183f7140254afef7c5610a3f488"
+checksum = "82ad8ddc14be1d4290cd68046e7d1d37acd408efed6d3ca08aefcc3ad6da069c"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
- "jsonrpsee-core 0.24.3",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -5032,15 +5101,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be0be325642e850ed0bdff426674d2e66b2b7117c9be23a7caef68a2902b7d9"
+checksum = "3264e339143fe37ed081953842ee67bfafa99e3b91559bdded6e4abd8fc8535e"
 dependencies = [
  "anyhow",
  "beef",
@@ -5052,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b67d6e008164f027afbc2e7bb79662650158d26df200040282d2aa1cbb093b"
+checksum = "a178c60086f24cc35bb82f57c651d0d25d99c4742b4d335de04e97fa1f08a8a1"
 dependencies = [
  "http 1.1.0",
  "serde",
@@ -5064,49 +5133,49 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7cbb3447cf14fd4d2f407c3cc96e6c9634d5440aa1fbed868a31f3c02b27f0"
+checksum = "9437dd0e8728897d0aa5a0075b8710266300e55ced07101ca0930fac4a611384"
 dependencies = [
- "jsonrpsee-client-transport 0.20.3",
- "jsonrpsee-core 0.20.3",
- "jsonrpsee-types 0.20.3",
+ "jsonrpsee-client-transport 0.20.4",
+ "jsonrpsee-core 0.20.4",
+ "jsonrpsee-types 0.20.4",
 ]
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0470d0ae043ffcb0cd323797a631e637fb4b55fe3eaa6002934819458bba62a7"
+checksum = "1a01cd500915d24ab28ca17527e23901ef1be6d659a2322451e1045532516c25"
 dependencies = [
- "jsonrpsee-client-transport 0.24.3",
- "jsonrpsee-core 0.24.3",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-client-transport 0.24.7",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca9cb3933ccae417eb6b08c3448eb1cb46e39834e5b503e395e5e5bd08546c0"
+checksum = "6d06eeabbb55f0af8405288390a358ebcceb6e79e1390741e6f152309c4d6076"
 dependencies = [
  "http 0.2.12",
- "jsonrpsee-client-transport 0.20.3",
- "jsonrpsee-core 0.20.3",
- "jsonrpsee-types 0.20.3",
+ "jsonrpsee-client-transport 0.20.4",
+ "jsonrpsee-core 0.20.4",
+ "jsonrpsee-types 0.20.4",
  "url",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.3"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bf67d1132f88edf4a4f8cff474cf01abb2be203004a2b8e11c2b20795b99e"
+checksum = "0fe322e0896d0955a3ebdd5bf813571c53fea29edd713bc315b76620b327e86d"
 dependencies = [
  "http 1.1.0",
- "jsonrpsee-client-transport 0.24.3",
- "jsonrpsee-core 0.24.3",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-client-transport 0.24.7",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
  "url",
 ]
 
@@ -5153,9 +5222,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9",
@@ -5212,7 +5281,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -5226,7 +5295,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
 ]
 
 [[package]]
@@ -5319,9 +5388,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libgit2-sys"
@@ -5372,11 +5441,11 @@ dependencies = [
 
 [[package]]
 name = "libproc"
-version = "0.14.8"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9ea4b75e1a81675429dafe43441df1caea70081e82246a8cccf514884a88bb"
+checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "errno",
  "libc",
 ]
@@ -5452,9 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.18"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -5501,11 +5570,11 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -5519,19 +5588,18 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.26.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958b4caa893816eea05507c20cfe47574a43d9a697138a7872990bba8a0ece68"
+checksum = "4d1febb2b4a79ddd1980eede06a8f7902197960aa0383ffcfdd62fe723036725"
 dependencies = [
- "libc",
  "lz4-sys",
 ]
 
 [[package]]
 name = "lz4-sys"
-version = "1.10.0"
+version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -5617,9 +5685,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -5671,17 +5739,18 @@ dependencies = [
 
 [[package]]
 name = "metrics-process"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb524e5438255eaa8aa74214d5a62713b77b2c3c6e3c0bbeee65cfd9a58948ba"
+checksum = "e69e6ced169644e186e060ddc15f3923fdf06862c811a867bb1e5e7c7824f4d0"
 dependencies = [
+ "libc",
  "libproc",
  "mach2",
  "metrics",
  "once_cell",
- "procfs",
+ "procfs 0.17.0",
  "rlimit",
- "windows 0.57.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -5709,7 +5778,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5755,11 +5824,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -5776,11 +5845,11 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
@@ -5810,7 +5879,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5872,15 +5941,15 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
  "url",
 ]
 
 [[package]]
 name = "multiaddr"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b852bc02a2da5feed68cd14fa50d0774b92790a5bdbfa932a813926c8472070"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
@@ -5891,7 +5960,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -5916,7 +5985,7 @@ dependencies = [
  "digest 0.10.7",
  "multihash-derive",
  "sha2 0.10.8",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -5926,7 +5995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
 dependencies = [
  "core2",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -6159,29 +6228,29 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6215,18 +6284,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -6236,13 +6305,13 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.2.7"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3041068147bb9abce8973644991e11c075fa8a7931a272bc8eb935971a2d03d7"
+checksum = "21aad1fbf80d2bcd7406880efc7ba109365f44bbb72896758ddcbfa46bf1592c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
@@ -6251,30 +6320,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-network"
-version = "0.2.7"
+name = "op-alloy-genesis"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf926fccb35a1ad784cf8c2771a3a7b2c891379fcc78bc7cdc23dec1b57a6459"
+checksum = "6e1b8a9b70da0e027242ec1762f0f3a386278b6291d00d12ff5a64929dc19f68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-primitives 0.8.8",
+ "alloy-sol-types",
+ "serde",
+ "serde_repr",
+]
+
+[[package]]
+name = "op-alloy-network"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783ce4ebc0a994eee2188431511b16692b704e1e8fff0c77d8c0354d3c2b1fc8"
+dependencies = [
+ "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-eth",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
 ]
 
 [[package]]
-name = "op-alloy-rpc-types"
-version = "0.2.7"
+name = "op-alloy-protocol"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f57a192b16bd94296637616908a5701d4318d6c2c5119c93a1df5442ec97c13"
+checksum = "bf300a82ae2d30e2255bfea87a2259da49f63a25a44db561ae64cc9e3084139f"
 dependencies = [
- "alloy-network",
- "alloy-primitives 0.8.7",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives 0.8.8",
+ "alloy-rlp",
+ "alloy-serde",
+ "hashbrown 0.14.5",
+ "op-alloy-consensus",
+ "op-alloy-genesis",
+ "serde",
+]
+
+[[package]]
+name = "op-alloy-rpc-types"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e281fbfc2198b7c0c16457d6524f83d192662bc9f3df70f24c3038d4521616df"
+dependencies = [
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "cfg-if",
+ "hashbrown 0.14.5",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -6282,13 +6384,18 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.2.7"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea246be3da604d2f68e86cc510cf05219db0ed24273ebd59d86065971ba0e3f"
+checksum = "2947272a81ebf988f4804b6f0f6a7c0b2f6f89a908cb410e36f8f3828f81c778"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-eips",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-engine",
  "alloy-serde",
+ "derive_more 1.0.0",
+ "op-alloy-consensus",
+ "op-alloy-genesis",
+ "op-alloy-protocol",
  "serde",
 ]
 
@@ -6325,9 +6432,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -6346,7 +6453,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6357,9 +6464,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -6375,9 +6482,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "4.2.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
+checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
 dependencies = [
  "num-traits",
 ]
@@ -6419,7 +6526,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6427,9 +6534,9 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -6474,7 +6581,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -6588,9 +6695,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -6609,10 +6716,11 @@ dependencies = [
 
 [[package]]
 name = "ph"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b7b74d575d7c11fb653fae69688be5206cafc1ead33c01ce61ac7f36eae45b"
+checksum = "2662713b3e8e02977b289a7ada32d672ae5477b5c23f290e5999122d53658847"
 dependencies = [
+ "aligned-vec",
  "binout",
  "bitm",
  "dyn_size_of",
@@ -6627,7 +6735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -6689,7 +6797,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6712,22 +6820,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6775,9 +6883,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plain_hasher"
@@ -6799,9 +6907,9 @@ dependencies = [
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -6812,15 +6920,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -7088,9 +7196,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -7100,9 +7208,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -7112,9 +7223,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -7122,15 +7233,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -7138,12 +7249,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7162,9 +7273,9 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "2.0.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f"
+checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
 dependencies = [
  "autocfg",
  "equivalent",
@@ -7183,11 +7294,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -7233,14 +7344,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -7256,7 +7367,19 @@ dependencies = [
  "flate2",
  "hex",
  "lazy_static",
- "procfs-core",
+ "procfs-core 0.16.0",
+ "rustix",
+]
+
+[[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.6.0",
+ "hex",
+ "procfs-core 0.17.0",
  "rustix",
 ]
 
@@ -7268,6 +7391,16 @@ checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
  "bitflags 2.6.0",
  "chrono",
+ "hex",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.6.0",
  "hex",
 ]
 
@@ -7300,7 +7433,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -7324,7 +7457,7 @@ checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7365,16 +7498,17 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 1.1.0",
- "rustls 0.23.12",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.15",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -7382,15 +7516,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash 1.1.0",
- "rustls 0.23.12",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.15",
  "slab",
  "thiserror",
  "tinyvec",
@@ -7399,21 +7533,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
  "socket2 0.5.7",
- "windows-sys 0.52.0",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -7548,9 +7683,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.1.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -7586,7 +7721,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-node-bindings",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rlp",
@@ -7623,10 +7758,10 @@ dependencies = [
  "futures",
  "governor",
  "humantime",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "integer-encoding",
  "itertools 0.11.0",
- "jsonrpsee 0.20.3",
+ "jsonrpsee 0.20.4",
  "lazy_static",
  "lru",
  "lz4_flex",
@@ -7658,11 +7793,11 @@ dependencies = [
  "reth-provider",
  "reth-trie",
  "reth-trie-parallel",
- "revm",
+ "revm 14.0.1",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 9.0.1",
  "rlp 0.6.1",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -7678,12 +7813,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.8.15",
+ "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
  "tungstenite 0.23.0",
  "url",
- "uuid 1.10.0",
+ "uuid 1.11.0",
  "warp",
  "web3",
  "zip",
@@ -7721,27 +7856,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
@@ -7750,14 +7876,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -7771,13 +7897,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -7788,9 +7914,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -7806,7 +7932,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
@@ -7835,14 +7961,14 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7851,8 +7977,8 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper 1.5.0",
+ "hyper-rustls 0.27.3",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -7864,9 +7990,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.12",
- "rustls-native-certs 0.7.1",
- "rustls-pemfile 2.1.2",
+ "rustls 0.23.15",
+ "rustls-native-certs 0.8.0",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7880,8 +8006,8 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.3",
- "winreg 0.52.0",
+ "webpki-roots 0.26.6",
+ "windows-registry",
 ]
 
 [[package]]
@@ -7897,7 +8023,6 @@ dependencies = [
 [[package]]
 name = "reth"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -7973,14 +8098,13 @@ dependencies = [
  "tempfile",
  "tikv-jemallocator",
  "tokio",
- "toml 0.8.15",
+ "toml 0.8.19",
  "tracing",
 ]
 
 [[package]]
 name = "reth-auto-seal-consensus"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "futures-util",
  "reth-beacon-consensus",
@@ -8008,7 +8132,6 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "futures-core",
@@ -8023,7 +8146,7 @@ dependencies = [
  "reth-revm",
  "reth-tasks",
  "reth-transaction-pool",
- "revm",
+ "revm 14.0.1",
  "tokio",
  "tracing",
 ]
@@ -8031,7 +8154,6 @@ dependencies = [
 [[package]]
 name = "reth-beacon-consensus"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "futures",
  "itertools 0.13.0",
@@ -8065,7 +8187,6 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "aquamarine",
  "linked_hash_set",
@@ -8096,7 +8217,6 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8108,7 +8228,6 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-signer",
  "alloy-signer-local",
@@ -8125,7 +8244,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-api",
  "reth-trie",
- "revm",
+ "revm 14.0.1",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8134,12 +8253,11 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-trie",
  "auto_impl",
  "derive_more 1.0.0",
@@ -8154,7 +8272,6 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "ahash",
  "backon",
@@ -8197,18 +8314,17 @@ dependencies = [
  "reth-static-file-types",
  "reth-trie",
  "reth-trie-db",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "serde",
  "serde_json",
  "tokio",
- "toml 0.8.15",
+ "toml 0.8.19",
  "tracing",
 ]
 
 [[package]]
 name = "reth-cli-runner"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8218,27 +8334,25 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "eyre",
  "libc",
  "rand 0.8.5",
  "reth-fs-util",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "thiserror",
 ]
 
 [[package]]
 name = "reth-codecs"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
@@ -8249,18 +8363,16 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "reth-config"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8268,13 +8380,12 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "serde",
- "toml 0.8.15",
+ "toml 0.8.19",
 ]
 
 [[package]]
 name = "reth-consensus"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
@@ -8284,7 +8395,6 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -8294,7 +8404,6 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8302,7 +8411,7 @@ dependencies = [
  "auto_impl",
  "eyre",
  "futures",
- "reqwest 0.12.5",
+ "reqwest 0.12.8",
  "reth-node-api",
  "reth-node-core",
  "reth-rpc-api",
@@ -8317,7 +8426,6 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -8348,7 +8456,6 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -8371,7 +8478,6 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-genesis",
  "boyer-moore-magiclen",
@@ -8397,7 +8503,6 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -8411,9 +8516,8 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "discv5",
  "enr 0.12.1",
@@ -8424,7 +8528,7 @@ dependencies = [
  "reth-net-nat",
  "reth-network-peers",
  "schnellru",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "serde",
  "thiserror",
  "tokio",
@@ -8435,9 +8539,8 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "derive_more 1.0.0",
  "discv5",
@@ -8450,7 +8553,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-metrics",
  "reth-network-peers",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "thiserror",
  "tokio",
  "tracing",
@@ -8459,9 +8562,8 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "data-encoding",
  "enr 0.12.1",
  "linked_hash_set",
@@ -8470,7 +8572,7 @@ dependencies = [
  "reth-network-peers",
  "reth-tokio-util",
  "schnellru",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -8481,7 +8583,6 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "futures",
@@ -8508,10 +8609,9 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "aes",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -8525,7 +8625,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "sha2 0.10.8",
  "sha3",
  "thiserror",
@@ -8539,7 +8639,6 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chainspec",
  "reth-payload-primitives",
@@ -8549,7 +8648,6 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "futures",
  "pin-project",
@@ -8573,7 +8671,6 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "futures",
  "metrics",
@@ -8608,7 +8705,6 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "eyre",
  "futures",
@@ -8627,7 +8723,7 @@ dependencies = [
  "reth-rpc-types",
  "reth-rpc-types-compat",
  "reth-trie",
- "revm-primitives",
+ "revm-primitives 9.0.1",
  "serde",
  "serde_json",
  "tokio",
@@ -8638,7 +8734,6 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -8651,7 +8746,6 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -8676,7 +8770,6 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -8692,7 +8785,6 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -8704,7 +8796,6 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "reth-chainspec",
@@ -8714,7 +8805,7 @@ dependencies = [
  "reth-primitives",
  "reth-rpc-types",
  "reth-rpc-types-compat",
- "revm-primitives",
+ "revm-primitives 9.0.1",
  "serde",
  "sha2 0.10.8",
 ]
@@ -8722,10 +8813,9 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "arbitrary",
  "auto_impl",
@@ -8742,7 +8832,6 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-basic-payload-builder",
  "reth-errors",
@@ -8755,14 +8844,13 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 14.0.1",
  "tracing",
 ]
 
 [[package]]
 name = "reth-etl"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8772,7 +8860,6 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-eips",
  "auto_impl",
@@ -8783,14 +8870,13 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-storage-errors",
- "revm",
- "revm-primitives",
+ "revm 14.0.1",
+ "revm-primitives 9.0.1",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-eips",
  "alloy-sol-types",
@@ -8803,13 +8889,12 @@ dependencies = [
  "reth-prune-types",
  "reth-revm",
  "reth-storage-api",
- "revm-primitives",
+ "revm-primitives 9.0.1",
 ]
 
 [[package]]
 name = "reth-evm-optimism"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -8820,8 +8905,8 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-revm",
- "revm",
- "revm-primitives",
+ "revm 14.0.1",
+ "revm-primitives 9.0.1",
  "thiserror",
  "tracing",
 ]
@@ -8829,34 +8914,31 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "derive_more 1.0.0",
  "nybbles",
  "reth-consensus",
  "reth-prune-types",
  "reth-storage-errors",
- "revm-primitives",
+ "revm-primitives 9.0.1",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-execution-errors",
  "reth-primitives",
  "reth-trie",
- "revm",
+ "revm 14.0.1",
 ]
 
 [[package]]
 name = "reth-exex"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "eyre",
  "futures",
@@ -8883,16 +8965,14 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "reth-provider",
 ]
 
 [[package]]
 name = "reth-fs-util"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "serde",
  "serde_json",
@@ -8902,32 +8982,30 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "async-trait",
  "bytes",
  "futures",
  "futures-util",
  "interprocess",
- "jsonrpsee 0.24.3",
+ "jsonrpsee 0.24.7",
  "pin-project",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
 name = "reth-libmdbx"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
- "dashmap 6.0.1",
+ "dashmap 6.1.0",
  "derive_more 1.0.0",
  "indexmap 2.6.0",
  "parking_lot 0.12.3",
@@ -8939,16 +9017,14 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "cc",
 ]
 
 [[package]]
 name = "reth-metrics"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "futures",
  "metrics",
@@ -8960,29 +9036,26 @@ dependencies = [
 [[package]]
 name = "reth-metrics-derive"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "reth-net-banlist"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
 ]
 
 [[package]]
 name = "reth-net-nat"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "futures-util",
- "reqwest 0.12.5",
+ "reqwest 0.12.8",
  "serde_with",
  "thiserror",
  "tokio",
@@ -8991,7 +9064,6 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -9026,7 +9098,7 @@ dependencies = [
  "reth-transaction-pool",
  "rustc-hash 2.0.0",
  "schnellru",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "serde",
  "smallvec",
  "thiserror",
@@ -9039,9 +9111,8 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-admin",
  "auto_impl",
  "derive_more 1.0.0",
@@ -9062,7 +9133,6 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "auto_impl",
  "derive_more 1.0.0",
@@ -9080,12 +9150,11 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "enr 0.12.1",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "serde_with",
  "thiserror",
  "tokio",
@@ -9095,7 +9164,6 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "humantime-serde",
  "reth-ethereum-forks",
@@ -9109,14 +9177,13 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "anyhow",
  "bincode",
  "cuckoofilter",
  "derive_more 1.0.0",
  "lz4_flex",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "ph",
  "reth-fs-util",
  "serde",
@@ -9129,7 +9196,6 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9147,7 +9213,6 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-network",
  "aquamarine",
@@ -9196,7 +9261,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9205,7 +9270,6 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-genesis",
  "alloy-rpc-types-engine",
@@ -9243,11 +9307,11 @@ dependencies = [
  "reth-storage-errors",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "serde",
  "serde_json",
  "shellexpand",
- "toml 0.8.15",
+ "toml 0.8.19",
  "tracing",
  "vergen",
 ]
@@ -9255,7 +9319,6 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "eyre",
  "reth-auto-seal-consensus",
@@ -9279,7 +9342,6 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rpc-types-engine",
  "futures",
@@ -9301,23 +9363,22 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "eyre",
  "http 1.1.0",
- "jsonrpsee 0.24.3",
+ "jsonrpsee 0.24.7",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
- "procfs",
+ "procfs 0.16.0",
  "reth-db-api",
  "reth-metrics",
  "reth-provider",
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "vergen",
 ]
@@ -9325,7 +9386,6 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chainspec",
  "reth-consensus",
@@ -9337,18 +9397,16 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
- "jsonrpsee-types 0.24.3",
+ "alloy-primitives 0.8.8",
+ "jsonrpsee-types 0.24.7",
  "op-alloy-network",
  "parking_lot 0.12.3",
- "reqwest 0.12.5",
+ "reqwest 0.12.8",
  "reth-chainspec",
  "reth-evm",
  "reth-evm-optimism",
@@ -9364,7 +9422,7 @@ dependencies = [
  "reth-rpc-types",
  "reth-tasks",
  "reth-transaction-pool",
- "revm",
+ "revm 14.0.1",
  "serde_json",
  "thiserror",
  "tokio",
@@ -9374,7 +9432,6 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "futures-util",
  "metrics",
@@ -9397,7 +9454,6 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chain-state",
  "reth-chainspec",
@@ -9413,7 +9469,6 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chainspec",
  "reth-primitives",
@@ -9424,12 +9479,11 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-serde",
@@ -9437,7 +9491,7 @@ dependencies = [
  "bytes",
  "c-kzg",
  "derive_more 1.0.0",
- "k256 0.13.3",
+ "k256 0.13.4",
  "modular-bitfield",
  "once_cell",
  "op-alloy-rpc-types",
@@ -9449,8 +9503,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-static-file-types",
  "reth-trie-common",
- "revm-primitives",
- "secp256k1 0.29.0",
+ "revm-primitives 9.0.1",
+ "secp256k1 0.29.1",
  "serde",
  "tempfile",
  "thiserror",
@@ -9460,12 +9514,11 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "arbitrary",
@@ -9476,7 +9529,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "reth-codecs",
- "revm-primitives",
+ "revm-primitives 9.0.1",
  "roaring",
  "serde",
 ]
@@ -9484,11 +9537,10 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rpc-types-engine",
  "auto_impl",
- "dashmap 6.0.1",
+ "dashmap 6.1.0",
  "itertools 0.13.0",
  "metrics",
  "once_cell",
@@ -9514,7 +9566,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
- "revm",
+ "revm 14.0.1",
  "strum",
  "tokio",
  "tracing",
@@ -9523,9 +9575,8 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "itertools 0.13.0",
  "metrics",
  "rayon",
@@ -9549,9 +9600,8 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "bytes",
  "derive_more 1.0.0",
  "modular-bitfield",
@@ -9563,7 +9613,6 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "reth-chainspec",
  "reth-consensus-common",
@@ -9572,26 +9621,25 @@ dependencies = [
  "reth-prune-types",
  "reth-storage-api",
  "reth-storage-errors",
- "revm",
+ "revm 14.0.1",
 ]
 
 [[package]]
 name = "reth-rpc"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "async-trait",
  "derive_more 1.0.0",
  "futures",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
- "jsonrpsee 0.24.3",
+ "hyper 1.5.0",
+ "jsonrpsee 0.24.7",
  "jsonwebtoken 9.3.0",
  "parking_lot 0.12.3",
  "pin-project",
@@ -9617,16 +9665,16 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 14.0.1",
  "revm-inspectors",
- "revm-primitives",
- "secp256k1 0.29.0",
+ "revm-primitives 9.0.1",
+ "secp256k1 0.29.1",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "tracing-futures",
 ]
@@ -9634,10 +9682,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-json-rpc",
- "jsonrpsee 0.24.3",
+ "jsonrpsee 0.24.7",
  "reth-engine-primitives",
  "reth-network-peers",
  "reth-primitives",
@@ -9648,10 +9695,9 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "http 1.1.0",
- "jsonrpsee 0.24.3",
+ "jsonrpsee 0.24.7",
  "metrics",
  "pin-project",
  "reth-chainspec",
@@ -9673,7 +9719,7 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "thiserror",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
 ]
@@ -9681,11 +9727,10 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "async-trait",
- "jsonrpsee-core 0.24.3",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
  "metrics",
  "reth-beacon-consensus",
  "reth-chainspec",
@@ -9709,7 +9754,6 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-rpc",
@@ -9718,8 +9762,8 @@ dependencies = [
  "auto_impl",
  "dyn-clone",
  "futures",
- "jsonrpsee 0.24.3",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee 0.24.7",
+ "jsonrpsee-types 0.24.7",
  "parking_lot 0.12.3",
  "reth-chainspec",
  "reth-errors",
@@ -9736,9 +9780,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 14.0.1",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 9.0.1",
  "tokio",
  "tracing",
 ]
@@ -9746,13 +9790,12 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-sol-types",
  "derive_more 1.0.0",
  "futures",
- "jsonrpsee-core 0.24.3",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
  "metrics",
  "rand 0.8.5",
  "reth-chain-state",
@@ -9770,9 +9813,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm",
+ "revm 14.0.1",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 9.0.1",
  "schnellru",
  "serde",
  "thiserror",
@@ -9784,24 +9827,22 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.1.0",
- "jsonrpsee-http-client 0.24.3",
+ "jsonrpsee-http-client 0.24.7",
  "pin-project",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
- "jsonrpsee-core 0.24.3",
- "jsonrpsee-types 0.24.3",
+ "alloy-primitives 0.8.8",
+ "jsonrpsee-core 0.24.7",
+ "jsonrpsee-types 0.24.7",
  "reth-errors",
  "reth-network-api",
  "reth-primitives",
@@ -9813,9 +9854,8 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
@@ -9825,7 +9865,7 @@ dependencies = [
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
  "alloy-serde",
- "jsonrpsee-types 0.24.3",
+ "jsonrpsee-types 0.24.7",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
 ]
@@ -9833,7 +9873,6 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
@@ -9845,7 +9884,6 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -9879,9 +9917,8 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "aquamarine",
  "auto_impl",
  "futures-util",
@@ -9906,9 +9943,8 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
@@ -9919,9 +9955,8 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "parking_lot 0.12.3",
  "rayon",
  "reth-db",
@@ -9939,9 +9974,8 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "clap",
  "derive_more 1.0.0",
  "serde",
@@ -9951,7 +9985,6 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "auto_impl",
  "reth-chainspec",
@@ -9967,7 +10000,6 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
@@ -9978,7 +10010,6 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9996,7 +10027,6 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10006,7 +10036,6 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "clap",
  "eyre",
@@ -10021,7 +10050,6 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "aquamarine",
@@ -10039,7 +10067,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-api",
  "reth-tasks",
- "revm",
+ "revm 14.0.1",
  "rustc-hash 2.0.0",
  "schnellru",
  "serde",
@@ -10053,7 +10081,6 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -10067,7 +10094,7 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 14.0.1",
  "tracing",
  "triehash",
 ]
@@ -10075,11 +10102,10 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-trie",
  "arbitrary",
@@ -10091,14 +10117,13 @@ dependencies = [
  "plain_hasher",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-primitives",
+ "revm-primitives 9.0.1",
  "serde",
 ]
 
 [[package]]
 name = "reth-trie-db"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "auto_impl",
@@ -10115,14 +10140,13 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "revm",
+ "revm 14.0.1",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
 version = "1.0.6"
-source = "git+https://github.com/taikoxyz/gwyneth?branch=gwyneth#b9f213f73bff01be454c7e879a33a5af1a81cb1e"
 dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
@@ -10146,13 +10170,26 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "14.0.1"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter 10.0.1",
+ "revm-precompile 11.0.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm"
+version = "14.0.1"
 source = "git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth#959611e7a6ceeb693acffe00ba8e4d976591479f"
 dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
- "revm-interpreter",
- "revm-precompile",
+ "revm-interpreter 10.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
+ "revm-precompile 11.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
  "serde",
  "serde_json",
 ]
@@ -10162,13 +10199,13 @@ name = "revm-inspectors"
 version = "0.6.0"
 source = "git+https://github.com/taikoxyz/revm-inspectors.git?branch=main-rbuilder#a7db16ce222d58eac84cfeeed4b5a9541dadc1d0"
 dependencies = [
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
  "colorchoice",
- "revm",
+ "revm 14.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
  "serde_json",
  "thiserror",
 ]
@@ -10176,10 +10213,35 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "10.0.1"
+dependencies = [
+ "revm-primitives 9.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "10.0.1"
 source = "git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth#959611e7a6ceeb693acffe00ba8e4d976591479f"
 dependencies = [
- "revm-primitives",
+ "revm-primitives 9.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
  "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "11.0.1"
+dependencies = [
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256 0.13.4",
+ "once_cell",
+ "revm-primitives 9.0.1",
+ "ripemd",
+ "secp256k1 0.29.1",
+ "sha2 0.10.8",
+ "substrate-bn",
 ]
 
 [[package]]
@@ -10188,16 +10250,33 @@ version = "11.0.1"
 source = "git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth#959611e7a6ceeb693acffe00ba8e4d976591479f"
 dependencies = [
  "aurora-engine-modexp",
- "blst",
  "c-kzg",
  "cfg-if",
- "k256 0.13.3",
+ "k256 0.13.4",
  "once_cell",
- "revm-primitives",
+ "revm-primitives 9.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
  "ripemd",
- "secp256k1 0.29.0",
+ "secp256k1 0.29.1",
  "sha2 0.10.8",
  "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "9.0.1"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives 0.8.8",
+ "auto_impl",
+ "bitflags 2.6.0",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "dyn-clone",
+ "enumn",
+ "hashbrown 0.14.5",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -10206,11 +10285,10 @@ version = "9.0.1"
 source = "git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth#959611e7a6ceeb693acffe00ba8e4d976591479f"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.7",
+ "alloy-primitives 0.8.8",
  "auto_impl",
  "bitflags 2.6.0",
  "bitvec",
- "c-kzg",
  "cfg-if",
  "dyn-clone",
  "enumn",
@@ -10287,9 +10365,9 @@ dependencies = [
 
 [[package]]
 name = "rlimit"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3560f70f30a0f16d11d01ed078a07740fe6b489667abc7c7b029155d9f21c3d8"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
 dependencies = [
  "libc",
 ]
@@ -10440,18 +10518,18 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.23",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -10474,15 +10552,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -10501,12 +10579,25 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -10523,46 +10614,45 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3beb939bcd33c269f4bf946cc829fcd336370267c4a927ac0399c84a3151a1"
+checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.12",
- "rustls-native-certs 0.7.1",
+ "rustls 0.23.15",
+ "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.8",
  "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.6",
  "winapi",
 ]
 
 [[package]]
 name = "rustls-platform-verifier-android"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -10576,9 +10666,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -10587,9 +10677,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -10645,7 +10735,7 @@ version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -10653,11 +10743,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10761,12 +10851,12 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "rand 0.8.5",
- "secp256k1-sys 0.10.0",
+ "secp256k1-sys 0.10.1",
  "serde",
 ]
 
@@ -10781,9 +10871,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -10804,9 +10894,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -10878,9 +10968,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -10896,23 +10986,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "indexmap 2.6.0",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -10929,10 +11020,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.6"
+name = "serde_repr"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.81",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -10951,9 +11053,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10969,14 +11071,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -11110,9 +11212,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
@@ -11150,9 +11252,9 @@ dependencies = [
 
 [[package]]
 name = "simdutf8"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -11166,9 +11268,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
+checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
 dependencies = [
  "console",
  "similar",
@@ -11346,9 +11448,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom",
  "unicode_categories",
@@ -11417,7 +11519,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -11501,7 +11603,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
- "uuid 1.10.0",
+ "uuid 1.11.0",
  "whoami",
 ]
 
@@ -11544,7 +11646,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
- "uuid 1.10.0",
+ "uuid 1.11.0",
  "whoami",
 ]
 
@@ -11571,7 +11673,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -11589,9 +11691,9 @@ dependencies = [
 [[package]]
 name = "ssz_rs"
 version = "0.9.0"
-source = "git+https://github.com/ralexstokes/ssz-rs.git#84ef2b71aa004f6767420badb42c902ad56b8b72"
+source = "git+https://github.com/ralexstokes/ssz-rs.git#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
 dependencies = [
- "alloy-primitives 0.7.7",
+ "alloy-primitives 0.8.8",
  "bitvec",
  "serde",
  "sha2 0.9.9",
@@ -11611,7 +11713,7 @@ dependencies = [
 [[package]]
 name = "ssz_rs_derive"
 version = "0.9.0"
-source = "git+https://github.com/ralexstokes/ssz-rs.git#84ef2b71aa004f6767420badb42c902ad56b8b72"
+source = "git+https://github.com/ralexstokes/ssz-rs.git#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11625,7 +11727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -11723,7 +11825,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -11736,7 +11838,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -11801,9 +11903,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11812,14 +11914,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e7b52ad118b2153644eea95c6fc740b6c1555b2344fdab763fc9de4075f665"
+checksum = "ebfc1bfd06acc78f16d8fd3ef846bc222ee7002468d10a7dce8d703d6eab89a3"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -11833,6 +11935,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -11909,14 +12014,15 @@ checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11954,28 +12060,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "reqwest 0.11.27",
- "syn 2.0.72",
+ "syn 2.0.81",
  "which",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -12117,14 +12223,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.1"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.1",
+ "mio 1.0.2",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
@@ -12141,7 +12247,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -12170,16 +12276,16 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.12",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -12222,19 +12328,19 @@ checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.12",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
  "tungstenite 0.23.0",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -12256,47 +12362,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.15"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2caab0bf757388c6c0ae23b3293fdb463fee59434529014f85e3263b995c28"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.16",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.6.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.15",
+ "winnow",
 ]
 
 [[package]]
@@ -12318,6 +12413,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -12344,24 +12453,24 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -12395,7 +12504,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -12442,9 +12551,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b8e455f6caa5212a102ec530bf86b8dc5a4c536299bffd84b238fed9119be7"
+checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
  "time",
  "tracing",
@@ -12597,7 +12706,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.12",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "sha1",
  "thiserror",
@@ -12622,9 +12731,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -12646,45 +12755,42 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
@@ -12699,15 +12805,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -12732,6 +12838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12745,18 +12857,18 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
+checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
 dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.12",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "url",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -12801,9 +12913,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
@@ -12838,9 +12950,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -12887,7 +12999,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "mime",
  "mime_guess",
@@ -12925,34 +13037,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -12962,9 +13075,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12972,28 +13085,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -13004,9 +13117,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13068,9 +13181,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -13089,11 +13202,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.7",
  "wasite",
 ]
 
@@ -13121,11 +13234,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13146,11 +13259,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -13165,44 +13278,66 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -13220,6 +13355,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -13347,18 +13491,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557404e450152cd6795bb558bca69e43c585055f4606e3bcae5894fc6dac9ba0"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -13368,16 +13503,6 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -13394,7 +13519,7 @@ dependencies = [
  "js-sys",
  "log",
  "pharos",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
  "thiserror",
  "wasm-bindgen",
@@ -13422,9 +13547,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63658493314859b4dfdf3fb8c1defd61587839def09582db50b8a4e93afca6bb"
+checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 
 [[package]]
 name = "yaml-rust"
@@ -13447,6 +13572,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -13458,7 +13584,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -13478,7 +13604,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -13525,7 +13651,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "zstd-safe 7.2.0",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -13550,18 +13676,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,8 +3028,8 @@ dependencies = [
  "reth-provider",
  "reth-trie",
  "reth-trie-db",
- "revm 14.0.1",
- "revm-primitives 9.0.1",
+ "revm",
+ "revm-primitives",
  "rustc-hash 2.0.0",
  "serde",
  "serde_json",
@@ -3987,7 +3987,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie",
- "revm 14.0.1",
+ "revm",
  "serde",
  "serde_json",
  "thiserror",
@@ -7793,9 +7793,9 @@ dependencies = [
  "reth-provider",
  "reth-trie",
  "reth-trie-parallel",
- "revm 14.0.1",
+ "revm",
  "revm-inspectors",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "rlp 0.6.1",
  "secp256k1 0.29.1",
  "serde",
@@ -8146,7 +8146,7 @@ dependencies = [
  "reth-revm",
  "reth-tasks",
  "reth-transaction-pool",
- "revm 14.0.1",
+ "revm",
  "tokio",
  "tracing",
 ]
@@ -8244,7 +8244,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-api",
  "reth-trie",
- "revm 14.0.1",
+ "revm",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8723,7 +8723,7 @@ dependencies = [
  "reth-rpc-types",
  "reth-rpc-types-compat",
  "reth-trie",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "serde",
  "serde_json",
  "tokio",
@@ -8805,7 +8805,7 @@ dependencies = [
  "reth-primitives",
  "reth-rpc-types",
  "reth-rpc-types-compat",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "serde",
  "sha2 0.10.8",
 ]
@@ -8844,7 +8844,7 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "reth-trie",
- "revm 14.0.1",
+ "revm",
  "tracing",
 ]
 
@@ -8870,8 +8870,8 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-storage-errors",
- "revm 14.0.1",
- "revm-primitives 9.0.1",
+ "revm",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -8889,7 +8889,7 @@ dependencies = [
  "reth-prune-types",
  "reth-revm",
  "reth-storage-api",
- "revm-primitives 9.0.1",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -8905,8 +8905,8 @@ dependencies = [
  "reth-primitives",
  "reth-prune-types",
  "reth-revm",
- "revm 14.0.1",
- "revm-primitives 9.0.1",
+ "revm",
+ "revm-primitives",
  "thiserror",
  "tracing",
 ]
@@ -8923,7 +8923,7 @@ dependencies = [
  "reth-consensus",
  "reth-prune-types",
  "reth-storage-errors",
- "revm-primitives 9.0.1",
+ "revm-primitives",
 ]
 
 [[package]]
@@ -8933,7 +8933,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-primitives",
  "reth-trie",
- "revm 14.0.1",
+ "revm",
 ]
 
 [[package]]
@@ -9422,7 +9422,7 @@ dependencies = [
  "reth-rpc-types",
  "reth-tasks",
  "reth-transaction-pool",
- "revm 14.0.1",
+ "revm",
  "serde_json",
  "thiserror",
  "tokio",
@@ -9503,7 +9503,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-static-file-types",
  "reth-trie-common",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "secp256k1 0.29.1",
  "serde",
  "tempfile",
@@ -9529,7 +9529,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "reth-codecs",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "roaring",
  "serde",
 ]
@@ -9566,7 +9566,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
- "revm 14.0.1",
+ "revm",
  "strum",
  "tokio",
  "tracing",
@@ -9621,7 +9621,7 @@ dependencies = [
  "reth-prune-types",
  "reth-storage-api",
  "reth-storage-errors",
- "revm 14.0.1",
+ "revm",
 ]
 
 [[package]]
@@ -9665,9 +9665,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm 14.0.1",
+ "revm",
  "revm-inspectors",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "secp256k1 0.29.1",
  "serde",
  "serde_json",
@@ -9780,9 +9780,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm 14.0.1",
+ "revm",
  "revm-inspectors",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "tokio",
  "tracing",
 ]
@@ -9813,9 +9813,9 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "reth-trie",
- "revm 14.0.1",
+ "revm",
  "revm-inspectors",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "schnellru",
  "serde",
  "thiserror",
@@ -10067,7 +10067,7 @@ dependencies = [
  "reth-primitives",
  "reth-storage-api",
  "reth-tasks",
- "revm 14.0.1",
+ "revm",
  "rustc-hash 2.0.0",
  "schnellru",
  "serde",
@@ -10094,7 +10094,7 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm 14.0.1",
+ "revm",
  "tracing",
  "triehash",
 ]
@@ -10117,7 +10117,7 @@ dependencies = [
  "plain_hasher",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-primitives 9.0.1",
+ "revm-primitives",
  "serde",
 ]
 
@@ -10140,7 +10140,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-common",
- "revm 14.0.1",
+ "revm",
  "tracing",
 ]
 
@@ -10174,22 +10174,8 @@ dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
- "revm-interpreter 10.0.1",
- "revm-precompile 11.0.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "revm"
-version = "14.0.1"
-source = "git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth#959611e7a6ceeb693acffe00ba8e4d976591479f"
-dependencies = [
- "auto_impl",
- "cfg-if",
- "dyn-clone",
- "revm-interpreter 10.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
- "revm-precompile 11.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
+ "revm-interpreter",
+ "revm-precompile",
  "serde",
  "serde_json",
 ]
@@ -10197,7 +10183,6 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.6.0"
-source = "git+https://github.com/taikoxyz/revm-inspectors.git?branch=main-rbuilder#a7db16ce222d58eac84cfeeed4b5a9541dadc1d0"
 dependencies = [
  "alloy-primitives 0.8.8",
  "alloy-rpc-types-eth",
@@ -10205,7 +10190,7 @@ dependencies = [
  "alloy-sol-types",
  "anstyle",
  "colorchoice",
- "revm 14.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
+ "revm",
  "serde_json",
  "thiserror",
 ]
@@ -10214,16 +10199,7 @@ dependencies = [
 name = "revm-interpreter"
 version = "10.0.1"
 dependencies = [
- "revm-primitives 9.0.1",
- "serde",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "10.0.1"
-source = "git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth#959611e7a6ceeb693acffe00ba8e4d976591479f"
-dependencies = [
- "revm-primitives 9.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
+ "revm-primitives",
  "serde",
 ]
 
@@ -10237,24 +10213,7 @@ dependencies = [
  "cfg-if",
  "k256 0.13.4",
  "once_cell",
- "revm-primitives 9.0.1",
- "ripemd",
- "secp256k1 0.29.1",
- "sha2 0.10.8",
- "substrate-bn",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "11.0.1"
-source = "git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth#959611e7a6ceeb693acffe00ba8e4d976591479f"
-dependencies = [
- "aurora-engine-modexp",
- "c-kzg",
- "cfg-if",
- "k256 0.13.4",
- "once_cell",
- "revm-primitives 9.0.1 (git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth)",
+ "revm-primitives",
  "ripemd",
  "secp256k1 0.29.1",
  "sha2 0.10.8",
@@ -10271,24 +10230,6 @@ dependencies = [
  "bitflags 2.6.0",
  "bitvec",
  "c-kzg",
- "cfg-if",
- "dyn-clone",
- "enumn",
- "hashbrown 0.14.5",
- "hex",
- "serde",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "9.0.1"
-source = "git+https://github.com/taikoxyz/revm.git?branch=v43-gwyneth#959611e7a6ceeb693acffe00ba8e4d976591479f"
-dependencies = [
- "alloy-eips",
- "alloy-primitives 0.8.8",
- "auto_impl",
- "bitflags 2.6.0",
- "bitvec",
  "cfg-if",
  "dyn-clone",
  "enumn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,29 +78,29 @@ alloy-signer-local = { version = "0.3.0" }
 alloy-sol-types = { version = "0.8.2", default-features = false }
 
 [patch.crates-io]
-revm = { git = "https://github.com/taikoxyz/revm.git", branch = "v43-gwyneth" }
-revm-primitives = { git = "https://github.com/taikoxyz/revm.git", branch = "v43-gwyneth" }
-revm-interpreter = { git = "https://github.com/taikoxyz/revm.git", branch = "v43-gwyneth" }
-revm-precompile = { git = "https://github.com/taikoxyz/revm.git", branch = "v43-gwyneth" }
+revm = { path = "../revm/crates/revm" }
+revm-primitives = { path = "../revm/crates/primitives" }
+revm-interpreter = { path = "../revm/crates/interpreter" }
+revm-precompile = { path = "../revm/crates/precompile" }
 revm-inspectors = { git = "https://github.com/taikoxyz/revm-inspectors.git", branch = "main-rbuilder" }
 
 [patch."https://github.com/paradigmxyz/reth"]
-reth = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-db = {git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-db-common = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-errors = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-libmdbx = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-payload-builder = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-node-api = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-trie = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-trie-parallel = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-basic-payload-builder = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-node-core = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-primitives = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-provider = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-chainspec = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-evm = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-evm-ethereum = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-db-api = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-execution-errors = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
-reth-trie-db = { git = "https://github.com/taikoxyz/gwyneth", branch = "gwyneth" }
+reth = { path = "../reth/bin/reth" }
+reth-db = {path = "../reth/crates/storage/db"}
+reth-db-common = { path = "../reth/crates/storage/db-common" }
+reth-errors = { path = "../reth/crates/errors" }
+reth-libmdbx = { path = "../reth/crates/storage/libmdbx-rs" }
+reth-payload-builder = { path = "../reth/crates/payload/builder" }
+reth-node-api = { path = "../reth/crates/node/api" }
+reth-trie = { path = "../reth/crates/trie/trie" }
+reth-trie-parallel = { path = "../reth/crates/trie/parallel" }
+reth-basic-payload-builder = { path = "../reth/crates/payload/basic" }
+reth-node-core = { path = "../reth/crates/node/core" }
+reth-primitives = { path = "../reth/crates/primitives" }
+reth-provider = { path = "../reth/crates/storage/provider" }
+reth-chainspec = { path = "../reth/crates/chainspec" }
+reth-evm = { path = "../reth/crates/evm" }
+reth-evm-ethereum = { path = "../reth/crates/ethereum/evm" }
+reth-db-api = { path = "../reth/crates/storage/db-api" }
+reth-execution-errors = { path = "../reth/crates/evm/execution-errors" }
+reth-trie-db = { path = "../reth/crates/trie/db" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ revm = { path = "../revm/crates/revm" }
 revm-primitives = { path = "../revm/crates/primitives" }
 revm-interpreter = { path = "../revm/crates/interpreter" }
 revm-precompile = { path = "../revm/crates/precompile" }
-revm-inspectors = { git = "https://github.com/taikoxyz/revm-inspectors.git", branch = "main-rbuilder" }
+revm-inspectors = { path = "../revm-inspectors" }
 
 [patch."https://github.com/paradigmxyz/reth"]
 reth = { path = "../reth/bin/reth" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ WORKDIR /app
 
 COPY ./rbuilder/Cargo.lock ./Cargo.lock
 COPY ./rbuilder/Cargo.toml ./Cargo.toml
-COPY ./rbuilder/.git ./.git
 COPY ./rbuilder/crates/ ./crates/
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -41,15 +40,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 FROM base as builder
 
-COPY --from=planner /app/recipe.json /rbuilder/recipe.json
-COPY ./rbuilder/Cargo.lock ./rbuilder/Cargo.lock
-COPY ./rbuilder/Cargo.toml ./rbuilder/Cargo.toml
-COPY ./rbuilder/.git ./rbuilder/.git
-COPY ./rbuilder/crates/ ./rbuilder/crates/
-COPY ./revm ./revm
-COPY ./revm-inspectors ./revm-inspectors
-
+COPY --from=planner /app/recipe.json /app/rbuilder/recipe.json
+COPY ./rbuilder/Cargo.lock /app/rbuilder/Cargo.lock
+COPY ./rbuilder/Cargo.toml /app/rbuilder/Cargo.toml
+COPY ./rbuilder/crates/ /app/rbuilder/crates/
+COPY ./reth /app/reth
+COPY ./revm /app/revm
+COPY ./revm-inspectors /app/revm-inspectors
+RUN ls
 WORKDIR /app/rbuilder
+RUN pwd && ls
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo chef cook --release --recipe-path recipe.json
 
@@ -62,7 +62,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # Runtime container
 #
-FROM gcr.io/distroless/cc-debian12
+FROM ubuntu:22.04 AS runtime
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ FROM ubuntu:22.04 AS runtime
 
 WORKDIR /app
 
-COPY --from=builder /app/rbuilder/target/release/rbuilder /app/rbuilder
+COPY --from=builder /app/rbuilder/target/release/rbuilder /usr/local/bin
 
-ENTRYPOINT ["/app/rbuilder"]
+# ENTRYPOINT ["/app/rbuilder"]
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ ENV SCCACHE_DIR=/sccache
 FROM base AS planner
 WORKDIR /app
 
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./.git ./.git
-COPY ./crates/ ./crates/
+COPY ./rbuilder/Cargo.lock ./Cargo.lock
+COPY ./rbuilder/Cargo.toml ./Cargo.toml
+COPY ./rbuilder/.git ./.git
+COPY ./rbuilder/crates/ ./crates/
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -47,10 +47,11 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo chef cook --release --recipe-path recipe.json
 
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./.git ./.git
-COPY ./crates/ ./crates/
+COPY ./rbuilder/Cargo.lock ./rbuilder/Cargo.lock
+COPY ./rbuilder/Cargo.toml ./rbuilder/Cargo.toml
+COPY ./rbuilder/.git ./rbuilder/.git
+COPY ./rbuilder/crates/ ./rbuilder/crates/
+COPY ./revm ./revm
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \

--- a/config-gwyneth-reth.toml
+++ b/config-gwyneth-reth.toml
@@ -10,11 +10,13 @@ reth_datadir = "/data/reth/execution-data/"
 # We can have multiple, separated by comma
 l2_reth_datadirs = ["/data/reth/gwyneth-167010"]
 
+gwyneth_chain_ids = [167010, 167011]
+
 coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
 optimistic_relay_secret_key = "env:OPTIMISTIC_RELAY_SECRET_KEY"
 
-# This shall be something like: "http://172.16.152.12:4000". To gather the correct IP, in (host machine) terminal we can query by: 
+# This shall be something like: "http://172.16.152.12:4000". To gather the correct IP, in (host machine) terminal we can query by:
 # docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' CL_CONTAINER_HASH
 # but it is auto-filled from now by the taiko reth's 'make install' process
 cl_node_url = [""]

--- a/config-gwyneth-reth.toml
+++ b/config-gwyneth-reth.toml
@@ -7,10 +7,11 @@ full_telemetry_server_ip = "0.0.0.0"
 
 chain = "/network-configs/genesis.json"
 reth_datadir = "/data/reth/execution-data/"
-# We can have multiple, separated by comma
-l2_reth_datadirs = ["/data/reth/gwyneth-167010"]
 
 gwyneth_chain_ids = [167010, 167011]
+l2_reth_datadirs = ["/data/reth/gwyneth-167010", "/data/reth/gwyneth-167011"]
+l2_ipc_paths = ["/tmp/reth.ipc-167010"]
+l2_server_ports = [9647, 9648]
 
 coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
@@ -25,7 +26,6 @@ jsonrpc_server_ip = "0.0.0.0"
 # Not exactly the same because the random postfix is generated every time, but something like: "/tmp/reth.ipc-3ZTH1DJ4"
 el_node_ipc_path = "/tmp/reth.ipc"
 # We can have multiple, separated by comma
-l2_el_node_ipc_paths = ["/tmp/reth.ipc-167010"]
 extra_data = "⚡🤖"
 
 dry_run = false

--- a/config-gwyneth-reth.toml
+++ b/config-gwyneth-reth.toml
@@ -1,3 +1,5 @@
+# This is auto-generated from kurtosis template:
+#   gwyneth-mono/ethereum-package/static_files/gwyneth/rbuilder_config.toml.tmpl
 log_json = false
 log_level = "info,rbuilder=debug"
 redacted_telemetry_server_port = 6061
@@ -6,30 +8,43 @@ full_telemetry_server_port = 6060
 full_telemetry_server_ip = "0.0.0.0"
 
 chain = "/network-configs/genesis.json"
-reth_datadir = "/data/reth/execution-data/"
+reth_datadir = "/data/reth/execution-data"
+el_node_ipc_path = "/tmp/ipc/l1.ipc"
 
-gwyneth_chain_ids = [167010, 167011]
-l2_reth_datadirs = ["/data/reth/gwyneth-167010", "/data/reth/gwyneth-167011"]
-l2_ipc_paths = ["/tmp/reth.ipc-167010"]
-l2_server_ports = [9647, 9648]
+gwyneth_chain_ids = [
+
+  160010,
+  160011,
+]
+l2_reth_datadirs = [
+
+  "/data/reth/gwyneth-160010",
+  "/data/reth/gwyneth-160011",
+]
+l2_ipc_paths = [
+
+  "/tmp/ipc/l2.ipc-160010",
+  "/tmp/ipc/l2.ipc-160011",
+]
+l2_server_ports = [
+
+  9647,
+  9648,
+]
+
 
 coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
 optimistic_relay_secret_key = "env:OPTIMISTIC_RELAY_SECRET_KEY"
 
-# This shall be something like: "http://172.16.152.12:4000". To gather the correct IP, in (host machine) terminal we can query by:
-# docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' CL_CONTAINER_HASH
-# but it is auto-filled from now by the taiko reth's 'make install' process
-cl_node_url = [""]
+cl_node_url = "http://172.16.32.12:4000"
 jsonrpc_server_port = 9646
 jsonrpc_server_ip = "0.0.0.0"
-# Not exactly the same because the random postfix is generated every time, but something like: "/tmp/reth.ipc-3ZTH1DJ4"
-el_node_ipc_path = "/tmp/reth.ipc"
-# We can have multiple, separated by comma
+
 extra_data = "⚡🤖"
 
 dry_run = false
-dry_run_validation_url = "http://localhost:8545"
+dry_run_validation_url = "http://172.16.32.10:8545"
 
 # blocks_processor_url can be an API service to record bids and transactions. It is not required.
 # blocks_processor_url = "http://block_processor.internal"
@@ -48,7 +63,7 @@ url = "http://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e
 priority = 0
 use_ssz_for_submit = false
 use_gzip_for_submit = false
-l1_rpc_url = "http://localhost:8545"
+l1_rpc_url =  "http://172.16.32.10:8545"
 l1_proposer_pk = "39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d"
 l1_smart_contract_address = "0x9fCF7D13d10dEdF17d0f24C62f0cf4ED462f65b7"
 

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -10,7 +10,7 @@ use crate::{
     primitives::SimulatedOrder,
     utils::clean_extradata,
 };
-use ahash::HashSet;
+use ahash::{HashMap, HashSet};
 use alloy_primitives::{Address, U256};
 use reth::providers::ProviderFactory;
 use reth_chainspec::ChainSpec;
@@ -86,8 +86,10 @@ pub fn backtest_prepare_ctx_for_block<DB: Database + Clone>(
         block_data.winning_bid_trace.proposer_fee_recipient,
         Some(builder_signer),
     );
+    let mut provider_factories = HashMap::default();
+    provider_factories.insert(chain_spec.chain.id(), provider_factory.clone());
     let (sim_orders, sim_errors) =
-        simulate_all_orders_with_sim_tree(provider_factory.clone(), &ctx, &orders, false)?;
+        simulate_all_orders_with_sim_tree(provider_factories, &ctx, &orders, false)?;
     Ok(BacktestBlockInput {
         ctx,
         sim_orders,

--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -38,7 +38,7 @@ pub fn sim_historical_block(
     let txs = extract_onchain_block_txs(&onchain_block)?;
 
     let suggested_fee_recipient = find_suggested_fee_recipient(&onchain_block, &txs);
-    let coinbase = onchain_block.header.miner;
+    let coinbase = ChainAddress(chain_spec.chain.id(), onchain_block.header.miner);
 
     let ctx = BlockBuildingContext::from_onchain_block(
         onchain_block,
@@ -50,7 +50,7 @@ pub fn sim_historical_block(
         None,
     );
 
-    let state_provider = provider_factory.history_by_block_hash(ctx.attributes.parent)?;
+    let state_provider = provider_factory.history_by_block_hash(ctx.chains[&chain_spec.chain().id()].attributes.parent)?;
     let mut partial_block = PartialBlock::new(true, None);
     let mut state = BlockState::new(state_provider, chain_spec.chain().id());
 
@@ -61,8 +61,6 @@ pub fn sim_historical_block(
     let mut cumulative_gas_used = 0;
     let mut cumulative_blob_gas_used = 0;
     let mut written_slots: HashMap<SlotKey, Vec<B256>> = HashMap::default();
-
-    let coinbase = ChainAddress(chain_spec.chain.id(), coinbase);
 
     for (idx, tx) in txs.into_iter().enumerate() {
         let coinbase_balance_before = state.balance(coinbase)?;

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -13,6 +13,7 @@ use rbuilder::{
 use reth::providers::BlockNumReader;
 use reth_payload_builder::database::SyncCachedReads as CachedReads;
 use reth_provider::StateProvider;
+use revm_primitives::ChainAddress;
 use std::{path::PathBuf, sync::Arc, time::Instant};
 use tracing::{debug, info};
 
@@ -62,7 +63,7 @@ async fn main() -> eyre::Result<()> {
         txs.len()
     );
 
-    let coinbase = onchain_block.header.miner;
+    let coinbase = ChainAddress(chain_spec.chain.id(), onchain_block.header.miner);
 
     let ctx = BlockBuildingContext::from_onchain_block(
         onchain_block,

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -192,7 +192,7 @@ impl DummyBuildingAlgorithm {
         &self,
         orders: Vec<SimulatedOrder>,
         provider_factory: HashMap<u64, ProviderFactory<DB>>,
-        ctx: &HashMap<u64, BlockBuildingContext>,
+        ctx: &BlockBuildingContext,
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>> {
         let mut block_building_helper = BlockBuildingHelperFromDB::new(
             provider_factory.clone(),

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -21,7 +21,7 @@ use rbuilder::{
         base_config::{
             DEFAULT_EL_NODE_IPC_PATH, DEFAULT_INCOMING_BUNDLES_PORT, DEFAULT_IP,
             DEFAULT_RETH_DB_PATH,
-        }, config::create_provider_factory, layer2_info::Layer2Info, order_input::{
+        }, config::create_provider_factory, layer2_info::{self, Layer2Info}, order_input::{
             OrderInputConfig, DEFAULT_INPUT_CHANNEL_BUFFER_SIZE, DEFAULT_RESULTS_CHANNEL_TIMEOUT,
             DEFAULT_SERVE_MAX_CONNECTIONS,
         }, payload_events::{MevBoostSlotData, MevBoostSlotDataGenerator}, simulation::SimulatedOrderCommand, LiveBuilder
@@ -66,6 +66,8 @@ async fn main() -> eyre::Result<()> {
         cancel.clone(),
     );
 
+    let layer2_info = Layer2Info::new(vec![], &vec![], &vec![], &vec![]).await?;
+
     let builder = LiveBuilder::<Arc<DatabaseEnv>, MevBoostSlotDataGenerator> {
         watchdog_timeout: Duration::from_secs(10000),
         error_storage_path: None,
@@ -95,7 +97,7 @@ async fn main() -> eyre::Result<()> {
         extra_rpc: RpcModule::new(()),
         sink_factory: Box::new(TraceBlockSinkFactory {}),
         builders: vec![Arc::new(DummyBuildingAlgorithm::new(10))],
-        layer2_info: Layer2Info::new(vec![], HashMap::default()).await?,
+        layer2_info,
     };
 
     let ctrlc = tokio::spawn(async move {

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -95,7 +95,7 @@ pub struct BlockBuildingHelperFromDB<DB> {
     /// Name of the builder that pregenerated this block.
     /// Might be ambiguous if several building parts were involved...
     builder_name: String,
-    building_ctx: HashMap<u64, BlockBuildingContext>,
+    building_ctx: BlockBuildingContext,
     built_block_trace: BuiltBlockTrace,
     /// Needed to get the initial state and the final root hash calculation.
     provider_factory: HashMap<u64, ProviderFactory<DB>>,
@@ -156,7 +156,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         provider_factory: HashMap<u64, ProviderFactory<DB>>,
         root_hash_task_pool: BlockingTaskPool,
         root_hash_config: RootHashConfig,
-        building_ctx: HashMap<u64, BlockBuildingContext>,
+        building_ctx: BlockBuildingContext,
         cached_reads: Option<CachedReads>,
         builder_name: String,
         discard_txs: bool,
@@ -170,7 +170,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         for (chain_id, provider_factory) in provider_factory.iter() {
             state_providers.insert(
                 *chain_id,
-                provider_factory.history_by_block_hash(building_ctx[chain_id].attributes.parent)?.into(),
+                provider_factory.history_by_block_hash(building_ctx.chains[chain_id].attributes.parent)?.into(),
             );
             if *chain_id > origin_chain_id {
                 origin_chain_id = *chain_id;
@@ -178,8 +178,8 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         }
         //println!("origin_chain_id: {}", origin_chain_id);
 
-        let fee_recipient_balance_start = state_providers[&building_ctx[&origin_chain_id].chain_spec.chain.id()]
-            .account_balance(building_ctx[&origin_chain_id].attributes.suggested_fee_recipient)?
+        let fee_recipient_balance_start = state_providers[&building_ctx.chains[&origin_chain_id].chain_spec.chain.id()]
+            .account_balance(building_ctx.chains[&origin_chain_id].attributes.suggested_fee_recipient)?
             .unwrap_or_default();
         let mut partial_block = PartialBlock::new(discard_txs, enforce_sorting)
             .with_tracer(GasUsedSimulationTracer::default());
@@ -187,7 +187,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         let mut block_state =
             BlockState::new_arc(state_providers).with_cached_reads(cached_reads.unwrap_or_default());
         partial_block
-            .pre_block_call(&building_ctx[&origin_chain_id], &mut block_state)
+            .pre_block_call(&building_ctx, &mut block_state)
             .map_err(|_| BlockBuildingHelperError::PreBlockCallFailed)?;
         // let payout_tx_gas = if building_ctx[&origin_chain_id].coinbase_is_suggested_fee_recipient() {
         //     None
@@ -242,7 +242,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         );
 
         trace!(
-            block = building_ctx.block_env.number.to::<u64>(),
+            block = building_ctx.chains[&building_ctx.parent_chain_id].block_env.number.to::<u64>(),
             build_time_mus = built_block_trace.fill_time.as_micros(),
             finalize_time_mus = built_block_trace.finalize_time.as_micros(),
             profit = format_ether(built_block_trace.bid_value),
@@ -284,12 +284,14 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         let bid_value = U256::from(self.partial_block.gas_used);
         let true_value = U256::from(self.partial_block.gas_used);
 
-        println!("gas used: {:?}", self.partial_block.gas_used);
+        if self.partial_block.gas_used > 0 {
+            println!("gas used: {:?}", self.partial_block.gas_used);
+        }
         // Since some extra money might arrived directly the suggested_fee_recipient (when suggested_fee_recipient != coinbase)
         // we check the fee_recipient delta and make our bid include that! This is supposed to be what the relay will check.
         let fee_recipient_balance_after = self
             .block_state
-            .balance(ChainAddress(self.origin_chain_id, self.building_ctx[&self.origin_chain_id].attributes.suggested_fee_recipient))?;
+            .balance(ChainAddress(self.origin_chain_id, self.building_ctx.chains[&self.origin_chain_id].attributes.suggested_fee_recipient))?;
         let fee_recipient_balance_diff = fee_recipient_balance_after
             .checked_sub(self._fee_recipient_balance_start)
             .unwrap_or_default();
@@ -311,7 +313,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
     ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
         let result =
             self.partial_block
-                .commit_order(order, &self.building_ctx[&self.origin_chain_id], &mut self.block_state);
+                .commit_order(order, &self.building_ctx, &mut self.block_state);
         println!("commit order: {:?}", order);
         match result {
             Ok(ok_result) => match ok_result {
@@ -338,14 +340,14 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
     }
 
     fn can_add_payout_tx(&self) -> bool {
-        !self.building_ctx[&self.origin_chain_id].coinbase_is_suggested_fee_recipient()
+        !self.building_ctx.chains[&self.origin_chain_id].coinbase_is_suggested_fee_recipient()
     }
 
     fn true_block_value(&self) -> Result<U256, BlockBuildingHelperError> {
         if let Some(payout_tx_gas) = self.payout_tx_gas {
             Ok(self
                 .partial_block
-                .get_proposer_payout_tx_value(payout_tx_gas, &self.building_ctx[&self.origin_chain_id])?)
+                .get_proposer_payout_tx_value(payout_tx_gas, &self.building_ctx)?)
         } else {
             Ok(self.partial_block.coinbase_profit)
         }
@@ -357,97 +359,148 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
         payout_tx_value: Option<U256>,
     ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
         //println!("finalize_block");
-        if payout_tx_value.is_some() && self.building_ctx[&self.origin_chain_id].coinbase_is_suggested_fee_recipient() {
+        if payout_tx_value.is_some() && self.building_ctx.chains[&self.origin_chain_id].coinbase_is_suggested_fee_recipient() {
             return Err(BlockBuildingHelperError::PayoutTxNotAllowed);
         }
         let start_time = Instant::now();
 
-        //println!("finalize_block_execution");
         self.finalize_block_execution(payout_tx_value)?;
-        //println!("finalize_block_execution done");
         // This could be moved outside of this func (pre finalize) since I don´t think the payout tx can change much.
         self.built_block_trace
-            .verify_bundle_consistency(&self.building_ctx[&self.origin_chain_id].blocklist)?;
+            .verify_bundle_consistency(&self.building_ctx.chains[&self.origin_chain_id].blocklist)?;
+
+        let provider_factory = &self.provider_factory[&self.building_ctx.parent_chain_id];
 
         let sim_gas_used = self.partial_block.tracer.used_gas;
-        let mut blocks = HashMap::default();
-        let mut cached_reads = CachedReads::default();
-        for (chain_id, provider_factory) in self.provider_factory.iter() {
-            // TODO Brecht: fix
-            if *chain_id == 160010 {
-                continue;
-            }
-
-            //println!("Creating block for chain {}", chain_id);
-
-            let block_number = self.building_context().block();
-            let finalized_block = match self.partial_block.clone().finalize(
-                &mut self.block_state,
-                &self.building_ctx[&self.origin_chain_id],
-                provider_factory.clone(),
-                self.root_hash_config.clone(),
-                self.root_hash_task_pool.clone(),
-            ) {
-                Ok(finalized_block) => finalized_block,
-                Err(err) => {
-                    if err.is_consistent_db_view_err() {
-                        let last_block_number = provider_factory
-                            .last_block_number()
-                            .unwrap_or_default();
-                        debug!(
-                            block_number,
-                            last_block_number, "Can't build on this head, cancelling slot"
-                        );
-                        self.cancel_on_fatal_error.cancel();
-                    }
-                    return Err(BlockBuildingHelperError::FinalizeError(err));
+        let block_number = self.building_context().block();
+        let finalized_block = match self.partial_block.clone().finalize(
+            &mut self.block_state,
+            &self.building_ctx,
+            provider_factory.clone(),
+            self.root_hash_config,
+            self.root_hash_task_pool,
+        ) {
+            Ok(finalized_block) => finalized_block,
+            Err(err) => {
+                if err.is_consistent_db_view_err() {
+                    let last_block_number = provider_factory
+                        .last_block_number()
+                        .unwrap_or_default();
+                    debug!(
+                        block_number,
+                        last_block_number, "Can't build on this head, cancelling slot"
+                    );
+                    self.cancel_on_fatal_error.cancel();
                 }
-            };
-            self.built_block_trace.update_orders_sealed_at();
-
-            self.built_block_trace.finalize_time = start_time.elapsed();
-
-            Self::trace_finalized_block(
-                &finalized_block,
-                &self.builder_name,
-                &self.building_ctx[&self.origin_chain_id],
-                &self.built_block_trace,
-                sim_gas_used,
-            );
-
-            let block = Block {
-                trace: self.built_block_trace.clone(),
-                sealed_block: finalized_block.sealed_block,
-                txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
-                builder_name: self.builder_name.clone(),
-            };
-
-            blocks.insert(*chain_id, block);
-            cached_reads = finalized_block.cached_reads;
-        }
-
-        let header = Header::default();
-        let block = RethBlock {
-            header,
-            //body: self.executed_tx.into_iter().map(|t| t.tx.into()).collect(),
-            // TODO Brecht: fix
-            body: blocks[&167010].sealed_block.body.clone(),
-            ommers: Vec::new(),
-            withdrawals: None,
-            requests: None,
+                return Err(BlockBuildingHelperError::FinalizeError(err));
+            }
         };
+        self.built_block_trace.update_orders_sealed_at();
+        //self.built_block_trace.root_hash_time = finalized_block.root_hash_time;
 
-        let block = Block {
-            trace: self.built_block_trace.clone(),
-            sealed_block: block.seal_slow(),
-            txs_blobs_sidecars: Vec::new(),
+        self.built_block_trace.finalize_time = start_time.elapsed();
+
+        Self::trace_finalized_block(
+            &finalized_block,
+            &self.builder_name,
+            &self.building_ctx,
+            &self.built_block_trace,
+            sim_gas_used,
+        );
+
+        let mut block = Block {
+            trace: self.built_block_trace,
+            sealed_block: finalized_block.sealed_block,
+            txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
             builder_name: self.builder_name.clone(),
         };
 
+        block.sealed_block.body = self.partial_block.executed_tx.into_iter().map(|t| t.tx.into()).collect();
+
         Ok(FinalizeBlockResult {
             block,
-            cached_reads,
+            cached_reads: finalized_block.cached_reads,
         })
+
+        // let sim_gas_used = self.partial_block.tracer.used_gas;
+        // let mut blocks = HashMap::default();
+        // let mut cached_reads = CachedReads::default();
+        // for (chain_id, provider_factory) in self.provider_factory.iter() {
+        //     // TODO Brecht: fix
+        //     if *chain_id == self.building_ctx.parent_chain_id {
+        //         continue;
+        //     }
+
+        //     //println!("Creating block for chain {}", chain_id);
+
+        //     let block_number = self.building_context().block();
+        //     let finalized_block = match self.partial_block.clone().finalize(
+        //         &mut self.block_state,
+        //         &self.building_ctx,
+        //         provider_factory.clone(),
+        //         self.root_hash_config.clone(),
+        //         self.root_hash_task_pool.clone(),
+        //     ) {
+        //         Ok(finalized_block) => finalized_block,
+        //         Err(err) => {
+        //             if err.is_consistent_db_view_err() {
+        //                 let last_block_number = provider_factory
+        //                     .last_block_number()
+        //                     .unwrap_or_default();
+        //                 debug!(
+        //                     block_number,
+        //                     last_block_number, "Can't build on this head, cancelling slot"
+        //                 );
+        //                 self.cancel_on_fatal_error.cancel();
+        //             }
+        //             return Err(BlockBuildingHelperError::FinalizeError(err));
+        //         }
+        //     };
+        //     self.built_block_trace.update_orders_sealed_at();
+
+        //     self.built_block_trace.finalize_time = start_time.elapsed();
+
+        //     Self::trace_finalized_block(
+        //         &finalized_block,
+        //         &self.builder_name,
+        //         &self.building_ctx,
+        //         &self.built_block_trace,
+        //         sim_gas_used,
+        //     );
+
+        //     let block = Block {
+        //         trace: self.built_block_trace.clone(),
+        //         sealed_block: finalized_block.sealed_block,
+        //         txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
+        //         builder_name: self.builder_name.clone(),
+        //     };
+
+        //     blocks.insert(*chain_id, block);
+        //     cached_reads = finalized_block.cached_reads;
+        // }
+
+        // let header = Header::default();
+        // let block = RethBlock {
+        //     header,
+        //     //body: self.executed_tx.into_iter().map(|t| t.tx.into()).collect(),
+        //     // TODO Brecht: fix
+        //     body: blocks[&167010].sealed_block.body.clone(),
+        //     ommers: Vec::new(),
+        //     withdrawals: None,
+        //     requests: None,
+        // };
+
+        // let block = Block {
+        //     trace: self.built_block_trace.clone(),
+        //     sealed_block: block.seal_slow(),
+        //     txs_blobs_sidecars: Vec::new(),
+        //     builder_name: self.builder_name.clone(),
+        // };
+
+        // Ok(FinalizeBlockResult {
+        //     block,
+        //     cached_reads,
+        // })
     }
 
     fn clone_cached_reads(&self) -> CachedReads {
@@ -459,7 +512,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
     }
 
     fn building_context(&self) -> &BlockBuildingContext {
-        &self.building_ctx[&self.origin_chain_id]
+        &self.building_ctx
     }
 
     fn box_clone(&self) -> Box<dyn BlockBuildingHelper> {

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -41,7 +41,7 @@ pub struct LiveBuilderInput<DB: Database> {
     pub provider_factory: HashMap<u64, ProviderFactory<DB>>,
     pub root_hash_config: RootHashConfig,
     pub root_hash_task_pool: BlockingTaskPool,
-    pub ctx: HashMap<u64, BlockBuildingContext>,
+    pub ctx: BlockBuildingContext,
     pub input: broadcast::Receiver<SimulatedOrderCommand>,
     pub sink: Arc<dyn UnfinishedBlockBuildingSink>,
     pub builder_name: String,
@@ -198,7 +198,7 @@ pub trait UnfinishedBlockBuildingSink: std::fmt::Debug + Send + Sync {
 #[derive(Debug)]
 pub struct BlockBuildingAlgorithmInput<DB: Database> {
     pub provider_factory: HashMap<u64, ProviderFactory<DB>>,
-    pub ctx: HashMap<u64, BlockBuildingContext>,
+    pub ctx: BlockBuildingContext,
     pub input: broadcast::Receiver<SimulatedOrderCommand>,
     /// output for the blocks
     pub sink: Arc<dyn UnfinishedBlockBuildingSink>,

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -110,6 +110,8 @@ pub struct BaseConfig {
 
     #[serde_as(as = "Vec<EnvOrValue<String>>")]
     pub l2_reth_datadirs: Vec<EnvOrValue<String>>,
+
+    pub gwyneth_chain_ids: Vec<u64>,
 }
 
 lazy_static! {
@@ -285,7 +287,7 @@ impl BaseConfig {
     }
 
     pub fn coinbase_signer(&self) -> eyre::Result<Signer> {
-        coinbase_signer_from_secret_key(&self.coinbase_secret_key.value()?)
+        coinbase_signer_from_secret_key(self.chain_spec().unwrap().chain.id(), &self.coinbase_secret_key.value()?)
     }
 
     pub fn extra_data(&self) -> eyre::Result<Vec<u8>> {
@@ -334,7 +336,7 @@ impl BaseConfig {
     pub fn resolve_l2_paths(&self) -> eyre::Result<(Vec<String>, Vec<String>)> {
         let ipc_paths = resolve_env_or_values(&self.l2_el_node_ipc_paths)?;
         let data_dirs = resolve_env_or_values(&self.l2_reth_datadirs)?;
-        
+
         if ipc_paths.len() != data_dirs.len() {
             return Err(eyre::eyre!("Number of L2 IPC paths and data directories must match"));
         }
@@ -463,6 +465,7 @@ impl Default for BaseConfig {
             //L2 related
             l2_el_node_ipc_paths: vec!["/tmp/reth.ipc".into()],
             l2_reth_datadirs: vec![DEFAULT_RETH_DB_PATH.into()],
+            gwyneth_chain_ids: Vec::new(),
         }
     }
 }
@@ -535,9 +538,9 @@ fn open_reth_db_rw(reth_db_path: &Path) -> eyre::Result<Arc<DatabaseEnv>> {
     ))
 }
 
-pub fn coinbase_signer_from_secret_key(secret_key: &str) -> eyre::Result<Signer> {
+pub fn coinbase_signer_from_secret_key(chain_id: u64, secret_key: &str) -> eyre::Result<Signer> {
     let secret_key = B256::from_str(secret_key)?;
-    Ok(Signer::try_from_secret(secret_key)?)
+    Ok(Signer::try_from_secret(chain_id, secret_key)?)
 }
 
 #[cfg(test)]

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -77,6 +77,7 @@ pub async fn run<ConfigType: LiveBuilderConfig>(
 
     let config: ConfigType = load_config_toml_and_env(cli.config)?;
     config.base_config().setup_tracing_subsriber()?;
+    println!("config from toml: {:?}", config);
 
     let cancel = CancellationToken::new();
 

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -310,7 +310,7 @@ impl LiveBuilderConfig for Config {
 
         let (wallet_balance_watcher, wallet_history) = WalletBalanceWatcher::new(
             provider_factory.provider_factory_unchecked(),
-            self.base_config.coinbase_signer()?.address,
+            self.base_config.coinbase_signer()?.address.1,
             WALLET_INIT_HISTORY_SIZE,
         )?;
         let bidding_service: Box<dyn BiddingService> =
@@ -336,7 +336,7 @@ impl LiveBuilderConfig for Config {
                 cancellation_token,
                 sink_factory,
                 payload_event,
-                vec![167010],
+                self.base_config.gwyneth_chain_ids.clone(),
                 provider_factory,
             )
             .await?;
@@ -352,6 +352,7 @@ impl LiveBuilderConfig for Config {
         let (l2_ipc_paths, l2_data_dirs) = self.base_config.resolve_l2_paths()?;
         println!("Dani debug: l2_el_node_ipc_paths are: {:?}", l2_ipc_paths);
         println!("Dani debug: l2_reth_datadirs are: {:?}", l2_data_dirs);
+        println!("gwyneth_chain_ids: {:?}", self.base_config.gwyneth_chain_ids);
 
         Ok(live_builder.with_builders_and_layer2_info(builders))
     }
@@ -469,9 +470,9 @@ fn open_reth_db(reth_db_path: &Path) -> eyre::Result<Arc<DatabaseEnv>> {
     ))
 }
 
-pub fn coinbase_signer_from_secret_key(secret_key: &str) -> eyre::Result<Signer> {
+pub fn coinbase_signer_from_secret_key(chain_id: u64, secret_key: &str) -> eyre::Result<Signer> {
     let secret_key = B256::from_str(secret_key)?;
-    Ok(Signer::try_from_secret(secret_key)?)
+    Ok(Signer::try_from_secret(chain_id, secret_key)?)
 }
 
 fn create_builders(
@@ -603,7 +604,7 @@ mod test {
                 .base_config
                 .coinbase_signer()
                 .expect("Coinbase signer")
-                .address,
+                .address.1,
             address!("75618c70B1BBF111F6660B0E3760387fb494102B")
         );
 

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -303,6 +303,7 @@ impl LiveBuilderConfig for Config {
         cancellation_token: tokio_util::sync::CancellationToken,
     ) -> eyre::Result<super::LiveBuilder<Arc<DatabaseEnv>, MevBoostSlotDataGenerator>> {
         let provider_factory = self.base_config.provider_factory()?;
+        let l2_provider_factories = self.base_config.gwyneth_provider_factories()?;
         let (sink_sealed_factory, relays) = self.l1_config.create_relays_sealed_sink_factory(
             self.base_config.chain_spec()?,
             Box::new(NullBidObserver {}),
@@ -336,8 +337,8 @@ impl LiveBuilderConfig for Config {
                 cancellation_token,
                 sink_factory,
                 payload_event,
-                self.base_config.gwyneth_chain_ids.clone(),
                 provider_factory,
+                l2_provider_factories
             )
             .await?;
         let root_hash_config = self.base_config.live_root_hash_config()?;
@@ -348,11 +349,6 @@ impl LiveBuilderConfig for Config {
             root_hash_task_pool,
             self.base_config.sbundle_mergeabe_signers(),
         );
-
-        let (l2_ipc_paths, l2_data_dirs) = self.base_config.resolve_l2_paths()?;
-        println!("Dani debug: l2_el_node_ipc_paths are: {:?}", l2_ipc_paths);
-        println!("Dani debug: l2_reth_datadirs are: {:?}", l2_data_dirs);
-        println!("gwyneth_chain_ids: {:?}", self.base_config.gwyneth_chain_ids);
 
         Ok(live_builder.with_builders_and_layer2_info(builders))
     }

--- a/crates/rbuilder/src/live_builder/layer2_info.rs
+++ b/crates/rbuilder/src/live_builder/layer2_info.rs
@@ -101,7 +101,7 @@ impl<DB: Clone> Layer2Info<DB> {
             });
         }
 
-        Ok(Self { 
+        Ok(Self {
             ipc_providers: Arc::new(Mutex::new(providers)),
             data_dirs: data_dirs_map,
             nodes,
@@ -129,11 +129,10 @@ impl<DB: Clone> Layer2Info<DB> {
         }
     }
 
-    pub async fn get_latest_block(&self, chain_id: u64) -> Result<Option<Block>> {
+    pub async fn get_latest_block(&self, chain_id: u64, block_id: BlockId) -> Result<Option<Block>> {
         if self.ensure_connection(&chain_id).await {
             let providers = self.ipc_providers.lock().unwrap();
             if let Some((provider, _)) = providers.get(&chain_id) {
-                let block_id = BlockId::Number(BlockNumberOrTag::Latest);
                 let transactions_kind = BlockTransactionsKind::Full;
                 let latest_block = provider.get_block(block_id, transactions_kind).await?;
                 Ok(latest_block)

--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -28,7 +28,7 @@ type BlockContextId = u64;
 /// Struct representing the need of order simulation for a particular block.
 #[derive(Debug, Clone)]
 pub struct SimulationContext {
-    pub block_ctx: HashMap<u64, BlockBuildingContext>,
+    pub block_ctx: BlockBuildingContext,
     /// Simulation requests come in through this channel.
     pub requests: flume::Receiver<SimulationRequest>,
     /// Simulation results go out through this channel.
@@ -101,7 +101,7 @@ impl<DB: Database + Clone + Send + 'static> OrderSimulationPool<DB> {
     /// @Pending: Not properly working to be used with several blocks at the same time (forks!).
     pub fn spawn_simulation_job(
         &self,
-        ctx: HashMap<u64, BlockBuildingContext>,
+        ctx: BlockBuildingContext,
         input: HashMap<u64, OrdersForBlock>,
         block_cancellation: CancellationToken,
     ) -> SlotOrderSimResults {
@@ -116,7 +116,7 @@ impl<DB: Database + Clone + Send + 'static> OrderSimulationPool<DB> {
         let handle = tokio::spawn(
             async move {
                 for (_chain_id, new_order_sub) in input {
-                    let sim_tree = SimTree::new(providers.clone(), ctx.iter().map(|(chain_id, ctx)| (*chain_id, ctx.attributes.parent)).collect());
+                    let sim_tree = SimTree::new(providers.clone(), ctx.chains.iter().map(|(chain_id, ctx)| (*chain_id, ctx.attributes.parent)).collect());
                     let new_order_sub = new_order_sub.new_order_sub;
                     let (sim_req_sender, sim_req_receiver) = flume::unbounded();
                     let (sim_results_sender, sim_results_receiver) = mpsc::channel(1024);
@@ -204,7 +204,7 @@ mod tests {
         orders_for_blocks.insert(test_context.chain_spec.chain.id(), orders_for_block);
         orders_for_blocks.insert(test_context.chain_spec.chain.id() + 1, orders_for_block2);
         let mut sim_results = sim_pool.spawn_simulation_job(
-            test_context.block_building_context_map(),
+            test_context.block_building_context(),
             orders_for_blocks,
             cancel.clone(),
         );

--- a/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
+++ b/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
@@ -49,20 +49,23 @@ pub fn run_sim_worker<DB: Database + Clone + Send + 'static>(
             sleep(Duration::from_millis(500));
         };
 
-        //TODO Brecht: fix
-        let chain_id = 167010;
-
         println!("Brecht: simming 3");
 
-        let provider_factory = match provider_factory[&chain_id].check_consistency_and_reopen_if_needed(
-            current_sim_context.block_ctx[&chain_id].block_env.number.to(),
-        ) {
-            Ok(provider_factory) => provider_factory,
-            Err(err) => {
-                error!(?err, "Error while reopening provider factory");
-                continue;
+        let mut provider_factories = HashMap::default();
+        for (chain_id, provider_factory) in provider_factory.iter() {
+            match provider_factory.check_consistency_and_reopen_if_needed(
+                current_sim_context.block_ctx.chains[chain_id].block_env.number.to(),
+            ) {
+                Ok(provider_factory) => {
+                    provider_factories.insert(*chain_id, provider_factory);
+                },
+                Err(err) => {
+                    error!(?err, "Error while reopening provider factory");
+                    // Decide whether to continue or break
+                    continue;
+                }
             }
-        };
+        }
 
         let mut cached_reads = CachedReads::default();
         let mut last_sim_finished = Instant::now();
@@ -70,39 +73,21 @@ pub fn run_sim_worker<DB: Database + Clone + Send + 'static>(
             let sim_thread_wait_time = last_sim_finished.elapsed();
             let sim_start = Instant::now();
 
-            // let state_provider = match provider_factory
-            //     .history_by_block_hash(current_sim_context.block_ctx[&chain_id].attributes.parent)
-            // {
-            //     Ok(state_provider) => state_provider,
-            //     Err(err) => {
-            //         error!(?err, "Error while getting state for block");
-            //         // break here so we can try to get new context
-            //         // @Metric
-            //         break;
-            //     }
-            // };
-            let start_time = Instant::now();
-            //let providers: HashMap = HashMap::default();
-            //providers.insert(chain_id, Arc::new(state_provider.clone()));
-            //providers.insert(160010, Arc::new(state_provider));
+            let state_for_sim = provider_factories.iter().map(|(chain_id, provider_factory)| {
+                (*chain_id, Arc::<dyn StateProvider>::from(
+                    provider_factory.history_by_block_hash(
+                        current_sim_context.block_ctx.chains[chain_id].attributes.parent
+                    ).expect("failed to open state provider")
+                ))
+            }).collect();
 
-            let mut state_for_sim: HashMap<u64, Arc<dyn StateProvider>> = HashMap::default();
-            println!("sim 2 chain_id: {}", chain_id);
-            // TODO(Brecht)
-            state_for_sim.insert(
-                160010,
-                Arc::<dyn StateProvider>::from(provider_factory.history_by_block_hash(current_sim_context.block_ctx[&chain_id].attributes.parent).expect("failed to open state provider")),
-            );
-            state_for_sim.insert(
-                167010,
-                Arc::<dyn StateProvider>::from(provider_factory.history_by_block_hash(current_sim_context.block_ctx[&chain_id].attributes.parent).expect("failed to open state provider")),
-            );
+            let start_time = Instant::now();
 
             let mut block_state = BlockState::new_arc(state_for_sim).with_cached_reads(cached_reads);
             let sim_result = simulate_order(
                 task.parents.clone(),
                 task.order.clone(),
-                &current_sim_context.block_ctx[&chain_id],
+                &current_sim_context.block_ctx,
                 &mut block_state,
             );
             match sim_result {

--- a/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
+++ b/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
@@ -49,8 +49,6 @@ pub fn run_sim_worker<DB: Database + Clone + Send + 'static>(
             sleep(Duration::from_millis(500));
         };
 
-        println!("Brecht: simming 3");
-
         let mut provider_factories = HashMap::default();
         for (chain_id, provider_factory) in provider_factory.iter() {
             match provider_factory.check_consistency_and_reopen_if_needed(

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -401,7 +401,7 @@ impl ShareBundle {
 #[derive(Derivative)]
 #[derivative(Clone, PartialEq, Eq)]
 pub struct TransactionSignedEcRecoveredWithBlobs {
-    tx: TransactionSignedEcRecovered,
+    pub tx: TransactionSignedEcRecovered,
     /// Will have a non empty BlobTransactionSidecar if TransactionSignedEcRecovered is 4844
     pub blobs_sidecar: Arc<BlobTransactionSidecar>,
 

--- a/crates/rbuilder/src/proposing/mod.rs
+++ b/crates/rbuilder/src/proposing/mod.rs
@@ -75,6 +75,9 @@ impl BlockProposer {
         // Create the transaction data
         let (meta, num_txs) = self.create_propose_block_tx_data(&execution_payload)?;
 
+        let propose_data = Rollup::proposeBlockCall { data: vec![meta.clone()] };
+        let propose_data = propose_data.abi_encode();
+
         // if num_txs == 1 {
         //     println!("skip propose");
         //     // If there's only the payout tx, don't propose
@@ -93,10 +96,6 @@ impl BlockProposer {
         // Sign the transaction
         let chain_id = provider.get_chain_id().await?;
         let nonce = provider.get_transaction_count(signer.address()).await.unwrap();
-
-        //let rollup = Rollup::(Address::from_str(&self.contract_address).unwrap(), provider);
-        let propose_data = Rollup::proposeBlockCall { data: vec![meta] };
-        let propose_data = propose_data.abi_encode();
 
         // Build a transaction to send 100 wei from Alice to Bob.
         // The `from` field is automatically filled to the first signer's address (Alice).

--- a/crates/rbuilder/src/utils/tx_signer.rs
+++ b/crates/rbuilder/src/utils/tx_signer.rs
@@ -2,23 +2,24 @@ use alloy_primitives::{Address, B256, U256};
 use reth_primitives::{
     public_key_to_address, Signature, Transaction, TransactionSigned, TransactionSignedEcRecovered,
 };
+use revm_primitives::ChainAddress;
 use secp256k1::{Message, SecretKey, SECP256K1};
 
 /// Simple struct to sign txs/messages.
 /// Mainly used to sign payout txs from the builder and to create test data.
 #[derive(Debug, Clone)]
 pub struct Signer {
-    pub address: Address,
+    pub address: ChainAddress,
     pub secret: SecretKey,
 }
 
 impl Signer {
-    pub fn try_from_secret(secret: B256) -> Result<Self, secp256k1::Error> {
+    pub fn try_from_secret(chain_id: u64, secret: B256) -> Result<Self, secp256k1::Error> {
         let secret = SecretKey::from_slice(secret.as_ref())?;
         let pubkey = secret.public_key(SECP256K1);
         let address = public_key_to_address(pubkey);
 
-        Ok(Self { address, secret })
+        Ok(Self { address: ChainAddress(chain_id, address), secret })
     }
 
     pub fn sign_message(&self, message: B256) -> Result<Signature, secp256k1::Error> {
@@ -42,12 +43,12 @@ impl Signer {
         let signed = TransactionSigned::from_transaction_and_signature(tx, signature);
         Ok(TransactionSignedEcRecovered::from_signed_transaction(
             signed,
-            self.address,
+            self.address.1,
         ))
     }
 
     pub fn random() -> Self {
-        Self::try_from_secret(B256::random()).expect("failed to create random signer")
+        Self::try_from_secret(0, B256::random()).expect("failed to create random signer")
     }
 }
 
@@ -61,8 +62,9 @@ mod test {
     fn test_sign_transaction() {
         let secret =
             fixed_bytes!("7a3233fcd52c19f9ffce062fd620a8888930b086fba48cfea8fc14aac98a4dce");
-        let address = address!("B2B9609c200CA9b7708c2a130b911dabf8B49B20");
-        let signer = Signer::try_from_secret(secret).expect("signer creation");
+        let chain_id = 1;
+        let address = ChainAddress(chain_id, address!("B2B9609c200CA9b7708c2a130b911dabf8B49B20"));
+        let signer = Signer::try_from_secret(chain_id, secret).expect("signer creation");
         assert_eq!(signer.address, address);
 
         let tx = Transaction::Eip1559(TxEip1559 {
@@ -71,15 +73,15 @@ mod test {
             gas_limit: 21000,
             max_fee_per_gas: 1000,
             max_priority_fee_per_gas: 20000,
-            to: TransactionKind::Call(address),
+            to: TransactionKind::Call(address.1),
             value: U256::from(3000u128),
             ..Default::default()
         });
 
         let signed_tx = signer.sign_tx(tx).expect("sign tx");
-        assert_eq!(signed_tx.signer(), address);
+        assert_eq!(signed_tx.signer(), address.1);
 
         let signed = signed_tx.into_signed();
-        assert_eq!(signed.recover_signer(), Some(address));
+        assert_eq!(signed.recover_signer(), Some(address.1));
     }
 }


### PR DESCRIPTION
- [ ] in cli make `ipc_paths`, `datadir` shared btw Reth configurable for multiple L2s https://github.com/CeciliaZ030/rbuilder/blob/60a4a55eb2b33f0dc7ed6e56e62084e19b889954/crates/rbuilder/src/live_builder/base_config.rs#L109
- [ ] changed how DB is started to remove the hardcoded ports & paths
